### PR TITLE
feat: integrate with 'did:cheqd'

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Masca enables everyone to build their <b>decentralized and self-sovereign identi
 Masca is built agnostic, leaving the user to choose his preferred **blockchain, DID method, protocol, and data store.** Everything is configurable, just like selecting the network in MetaMask. Currently supported technologies:
 
 - **Blockchains:** EVM blockchains supported by integrated DID methods
-- **DID methods:** `did:ethr`, `did:key`, `did:key (EBSI)` `did:pkh`, `did:jwk`, `did:polygonid`, `did:iden3`
+- **DID methods:** `did:ethr`, `did:key`, `did:key (EBSI)` `did:pkh`, `did:jwk`, `did:polygonid`, `did:iden3`, `did:cheqd`
 - **Protocols**: OpenID Connect, Polygon ID
 - **Credentials and Presentations:** Create & Verify Credentials/Presentations
 - **Data stores:** MetaMask Snap state (local & encrypted), Ceramic Network

--- a/packages/dapp/package.json
+++ b/packages/dapp/package.json
@@ -22,6 +22,8 @@
     "@blockchain-lab-um/extended-verification": "0.3.0",
     "@blockchain-lab-um/masca-connector": "1.5.0",
     "@blockchain-lab-um/oidc-types": "0.2.0-beta.0",
+    "@cheqd/did-provider-cheqd": "^4.6.4",
+    "@cheqd/sdk": "^5.3.7",
     "@headlessui/react": "^2.0.3",
     "@heroicons/react": "^2.1.3",
     "@nextui-org/react": "^2.3.6",

--- a/packages/dapp/src/app/api/veramoSetup.ts
+++ b/packages/dapp/src/app/api/veramoSetup.ts
@@ -36,6 +36,13 @@ import {
 } from 'ens-did-resolver';
 import { JsonRpcProvider } from 'ethers';
 import { getResolver as didEthrResolver } from 'ethr-did-resolver';
+import {
+  CheqdDIDProvider,
+  getResolver as didCheqdResolver,
+  DefaultRPCUrls,
+  DefaultResolverUrl,
+} from '@cheqd/did-provider-cheqd';
+import { CheqdNetwork } from '@cheqd/sdk';
 
 export type Agent = TAgent<
   IDIDManager &
@@ -90,6 +97,18 @@ export const getAgent = async (): Promise<Agent> => {
             defaultKms: 'local',
             chainId: '0x01',
           }),
+          'did:cheqd:mainnet': new CheqdDIDProvider({
+            defaultKms: 'local',
+            networkType: CheqdNetwork.Mainnet,
+            rpcUrl: DefaultRPCUrls.mainnet,
+            cosmosPayerSeed: process.env.FEE_PAYER_MNEMONIC || '',
+          }),
+          'did:cheqd:testnet': new CheqdDIDProvider({
+            defaultKms: 'local',
+            networkType: CheqdNetwork.Testnet,
+            rpcUrl: DefaultRPCUrls.testnet,
+            cosmosPayerSeed: process.env.FEE_PAYER_MNEMONIC || '',
+          }),
         },
       }),
       new KeyManager({
@@ -106,6 +125,7 @@ export const getAgent = async (): Promise<Agent> => {
           ...didEnsResolver({
             networks: networks as unknown as ProviderConfiguration[],
           }),
+          ...didCheqdResolver({ url: DefaultResolverUrl }),
         }),
       }),
     ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,6 +468,12 @@ importers:
       '@blockchain-lab-um/oidc-types':
         specifier: 0.2.0-beta.0
         version: link:../../libs/oidc/types
+      '@cheqd/did-provider-cheqd':
+        specifier: ^4.6.4
+        version: 4.6.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(node-fetch@2.7.0(encoding@0.1.13))(react@18.3.1)(typescript@5.4.5)(web-streams-polyfill@4.0.0)
+      '@cheqd/sdk':
+        specifier: ^5.3.7
+        version: 5.3.7(bufferutil@4.0.8)(debug@4.4.3)
       '@headlessui/react':
         specifier: ^2.0.3
         version: 2.0.3(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -527,7 +533,7 @@ importers:
         version: 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
       '@veramo/credential-w3c':
         specifier: 6.0.0
-        version: 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+        version: 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
       '@veramo/did-manager':
         specifier: 6.0.0
         version: 6.0.0
@@ -1129,6 +1135,9 @@ packages:
   '@ampproject/remapping@2.3.0':
     resolution: {integrity: sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==}
     engines: {node: '>=6.0.0'}
+
+  '@assemblyscript/loader@0.9.4':
+    resolution: {integrity: sha512-HazVq9zwTVwGmqdwYzu7WyQ6FQVZ7SwET0KKQuKm55jD0IfUpZgN0OPIiZG3zV1iSrVYcN0bdwLRXI/VNCYsUA==}
 
   '@astronautlabs/jsonpath@1.1.2':
     resolution: {integrity: sha512-FqL/muoreH7iltYC1EB5Tvox5E8NSOOPGkgns4G+qxRKl6k5dxEVljUjB5NcKESzkqwnUqWjSZkL61XGYOuV+A==}
@@ -2988,6 +2997,12 @@ packages:
     resolution: {integrity: sha512-R524tD5VwOt3QRHr7N518nqTVR/HKgfWL4LypekcGuNQN8R4PWScvuRcRzrY39A28kLztMv+TJdiKuMNbkU1ug==}
     engines: {node: '>=8.9'}
 
+  '@borewit/text-codec@0.1.1':
+    resolution: {integrity: sha512-5L/uBxmjaCIX5h8Z+uu+kA9BQLkc/Wl06UGR5ajNRxu+/XjonB5i8JpgFMrPj3LXTCPA0pv8yxUvbUi+QthGGA==}
+
+  '@bufbuild/protobuf@2.10.2':
+    resolution: {integrity: sha512-uFsRXwIGyu+r6AMdz+XijIIZJYpoWeYzILt5yZ2d3mCjQrWUTVpVD9WL/jZAbvp+Ed04rOhrsk7FiTcEDseB5A==}
+
   '@cef-ebsi/ebsi-did-resolver@3.2.0':
     resolution: {integrity: sha512-4wM5TK5l6xRBSkOCEZRP64Xqsd0BqmvjfSpREn8fXbrpMZqOafku77YQSMzqFmOIQ62HSEi5Vf4CSzDHAmalig==}
     engines: {node: '>=16.10.0'}
@@ -3093,6 +3108,22 @@ packages:
   '@changesets/write@0.3.0':
     resolution: {integrity: sha512-slGLb21fxZVUYbyea+94uFiD6ntQW0M2hIKNznFizDhZPDgn2c/fv1UzzlW43RVzh1BEDuIqW6hzlJ1OflNmcw==}
 
+  '@cheqd/did-provider-cheqd@4.6.4':
+    resolution: {integrity: sha512-16DkjnpKGs+mmrnuiVHdSR9kD+ZCkMCcmNydQmP9yuLVtC9SGYxR5EY5LepEiDPILSIB3+cf1TnYkVNf621Yaw==}
+    engines: {node: '>=20.0.0'}
+
+  '@cheqd/sdk@5.3.7':
+    resolution: {integrity: sha512-Wt/TMPfjuEbTfeJNwHFx0uSeu3xlm6x6RmgmqIf6a2q38c1jlnYxMgMAaobEzmrIbox/WdAPYjKR1ccLlh6/cA==}
+    engines: {node: '>=22.0.0'}
+
+  '@cheqd/ts-proto@2.5.0':
+    resolution: {integrity: sha512-3KqyvcruFxvkz+p6LnSCyUnqBJ2bJeOnIDkaYoAMcmGcSNKti3VECOKGdjjEO3rG/0/gAR9bhEHu9j1mUKSFqA==}
+    engines: {node: '>=20'}
+
+  '@cheqd/ts-proto@4.2.0':
+    resolution: {integrity: sha512-0/pKFSDtERs5euLW0mcry3Lr9mguDY3Sr+W9uzs7Iru6HEBxs+LjwcpaFr9073wlsKF9fLhsCDHvDJDwNxePkg==}
+    engines: {node: '>=22.0.0'}
+
   '@coinbase/wallet-sdk@3.9.1':
     resolution: {integrity: sha512-cGUE8wm1/cMI8irRMVOqbFWYcnNugqCtuy2lnnHfgloBg+GRLs9RsrkOUDMdv/StfUeeKhCDyYudsXXvcL1xIA==}
 
@@ -3169,8 +3200,79 @@ packages:
     resolution: {integrity: sha512-tpyc+7i6bPG9mvaBbtKUeghfyZSDgWquIDfMgqYtTbmZ9Y9VzEm2je9EYcQ0aoz5o7NvGS+rcDec93yO08MHYA==}
     engines: {node: '>=v18'}
 
+  '@confio/ics23@0.6.8':
+    resolution: {integrity: sha512-wB6uo+3A50m0sW/EWcU64xpV/8wShZ6bMTa7pF8eYsTrSkQA7oLUIJcs/wb8g4y2Oyq701BaGiO6n/ak5WXO1w==}
+    deprecated: Unmaintained. The codebase for this package was moved to https://github.com/cosmos/ics23 but then the JS implementation was removed in https://github.com/cosmos/ics23/pull/353. Please consult the maintainers of https://github.com/cosmos for further assistance.
+
   '@corex/deepmerge@4.0.43':
     resolution: {integrity: sha512-N8uEMrMPL0cu/bdboEWpQYb/0i2K5Qn8eCsxzOmxSggJbbQte7ljMRoXm917AbntqTGOzdTu+vP3KOOzoC70HQ==}
+
+  '@cosmjs/amino@0.30.1':
+    resolution: {integrity: sha512-yNHnzmvAlkETDYIpeCTdVqgvrdt1qgkOXwuRVi8s27UKI5hfqyE9fJ/fuunXE6ZZPnKkjIecDznmuUOMrMvw4w==}
+
+  '@cosmjs/amino@0.36.2':
+    resolution: {integrity: sha512-r4yV1bhl412gwHGlyaUaJHIJnmldtyGsAwyz3oHHVxduiECj06Rv6wqeyLZfQa9W6hU+MlZwy7LabSUkkyGwjA==}
+
+  '@cosmjs/crypto@0.30.1':
+    resolution: {integrity: sha512-rAljUlake3MSXs9xAm87mu34GfBLN0h/1uPPV6jEwClWjNkAMotzjC0ab9MARy5FFAvYHL3lWb57bhkbt2GtzQ==}
+    deprecated: This uses elliptic for cryptographic operations, which contains several security-relevant bugs. To what degree this affects your application is something you need to carefully investigate. See https://github.com/cosmos/cosmjs/issues/1708 for further pointers. Starting with version 0.34.0 the cryptographic library has been replaced. However, private keys might still be at risk.
+
+  '@cosmjs/crypto@0.36.2':
+    resolution: {integrity: sha512-QL4NHtcqR6DEKIN200aLeR8gKO433K0f5avKV0TVFP/g12UtnEGSk79PJq5Gv1PLc9GtATHgLLQI/3D8TEe+ig==}
+
+  '@cosmjs/encoding@0.30.1':
+    resolution: {integrity: sha512-rXmrTbgqwihORwJ3xYhIgQFfMSrwLu1s43RIK9I8EBudPx3KmnmyAKzMOVsRDo9edLFNuZ9GIvysUCwQfq3WlQ==}
+
+  '@cosmjs/encoding@0.36.2':
+    resolution: {integrity: sha512-i3+P1EKYoLcONAsmpJPhDAc3Wh3ajZNRHt/hczi/JEQXmleTJLVzv2mXUyllM6Qa+B6ybbr3Z2lnEFa8L3yLqg==}
+
+  '@cosmjs/json-rpc@0.30.1':
+    resolution: {integrity: sha512-pitfC/2YN9t+kXZCbNuyrZ6M8abnCC2n62m+JtU9vQUfaEtVsgy+1Fk4TRQ175+pIWSdBMFi2wT8FWVEE4RhxQ==}
+
+  '@cosmjs/json-rpc@0.36.2':
+    resolution: {integrity: sha512-3IRamylHVCxBevXGlnIoWUdJCLsP5LwHbXYUsBnC9T8UttZ5oYRN5gDf6+2dQEPk+p9xOv2i8xrCwNWxo7675Q==}
+
+  '@cosmjs/math@0.30.1':
+    resolution: {integrity: sha512-yaoeI23pin9ZiPHIisa6qqLngfnBR/25tSaWpkTm8Cy10MX70UF5oN4+/t1heLaM6SSmRrhk3psRkV4+7mH51Q==}
+
+  '@cosmjs/math@0.36.2':
+    resolution: {integrity: sha512-uJZRzxqnBk3MgxFgeyUwLgUzWkAIcmznWSB/tgGCjGCnUNebzI+44dA3ncEDCMqQysi/MZ+cSwAcDU7IY2PFeA==}
+
+  '@cosmjs/proto-signing@0.30.1':
+    resolution: {integrity: sha512-tXh8pPYXV4aiJVhTKHGyeZekjj+K9s2KKojMB93Gcob2DxUjfKapFYBMJSgfKPuWUPEmyr8Q9km2hplI38ILgQ==}
+
+  '@cosmjs/proto-signing@0.36.2':
+    resolution: {integrity: sha512-dyZsgZBQgGkaE4cazHVX8GDwrRJVKUVDnrODkyFXVNbxMnm4t6nxpK1qwgY9GHlWUhck3Dh9NT3BoMbXiMYTZQ==}
+
+  '@cosmjs/socket@0.30.1':
+    resolution: {integrity: sha512-r6MpDL+9N+qOS/D5VaxnPaMJ3flwQ36G+vPvYJsXArj93BjgyFB7BwWwXCQDzZ+23cfChPUfhbINOenr8N2Kow==}
+
+  '@cosmjs/socket@0.36.2':
+    resolution: {integrity: sha512-Pb7JcTFWnq6yfY0IEejHrpSxNDJYcqjjAa1D29a6b/obk4qa4o3oIV5bIx6zAbdRq8uLoBfvWs0bHTNnVuBWJg==}
+
+  '@cosmjs/stargate@0.30.1':
+    resolution: {integrity: sha512-RdbYKZCGOH8gWebO7r6WvNnQMxHrNXInY/gPHPzMjbQF6UatA6fNM2G2tdgS5j5u7FTqlCI10stNXrknaNdzog==}
+
+  '@cosmjs/stargate@0.36.2':
+    resolution: {integrity: sha512-vnNK4dXF+s2v1aKPfYxKVrvXPcnBQb8rPoBScnTpPWnRt3XXbLw7Oo6fTQQWwKYNKQzi6DOApeEB+bCYcaPAAw==}
+
+  '@cosmjs/stream@0.30.1':
+    resolution: {integrity: sha512-Fg0pWz1zXQdoxQZpdHRMGvUH5RqS6tPv+j9Eh7Q953UjMlrwZVo0YFLC8OTf/HKVf10E4i0u6aM8D69Q6cNkgQ==}
+
+  '@cosmjs/stream@0.36.2':
+    resolution: {integrity: sha512-FlZx2Buovem837LdTLPkPFcxzuQ7zierAqSXwMPr/MG3k+qMxHNfLFTTCXMNWQ4ZlbYedud8ZqCL3/HKdS5mig==}
+
+  '@cosmjs/tendermint-rpc@0.30.1':
+    resolution: {integrity: sha512-Z3nCwhXSbPZJ++v85zHObeUggrEHVfm1u18ZRwXxFE9ZMl5mXTybnwYhczuYOl7KRskgwlB+rID0WYACxj4wdQ==}
+
+  '@cosmjs/tendermint-rpc@0.36.2':
+    resolution: {integrity: sha512-76Z99C1NVf/Yv/1bWU0wul8MhRwVdqiZxqU5bcHqvJLoQ2nKUfGpSSYRdbMHfZ63J8ryRqQ95uPvPTfrBb+agw==}
+
+  '@cosmjs/utils@0.30.1':
+    resolution: {integrity: sha512-KvvX58MGMWh7xA+N+deCfunkA/ZNDvFLw4YbOmX3f/XBIkqrVY7qlotfy2aNb1kgp6h4B6Yc8YawJPDTfvWX7g==}
+
+  '@cosmjs/utils@0.36.2':
+    resolution: {integrity: sha512-OOr2HU/Ph+/GI1Fx2UCf3LOyX9YTCP51d2HitTOjjEJRYnkfKXP3lMBl1FZo5QaFWxnfuBc+Cj+cSoiQUJRyzQ==}
 
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
@@ -3220,6 +3322,13 @@ packages:
     resolution: {integrity: sha512-b7sPDTNHdySoJ+Rp2p06x3rg1iTxI4yPTTA3PrPh40xcvFJ0K/YhdIb/Rzff13t92arcJ+VYGFhqtJorauV91g==}
     engines: {node: '>=14.14'}
 
+  '@digitalbazaar/bitstring@3.1.0':
+    resolution: {integrity: sha512-Cii+Sl++qaexOvv3vchhgZFfSmtHPNIPzGegaq4ffPnflVXFu+V2qrJ17aL2+gfLxrlC/zazZFuAltyKTPq7eg==}
+    engines: {node: '>=16'}
+
+  '@digitalbazaar/credentials-context@3.2.0':
+    resolution: {integrity: sha512-WruXZAF182pCYq/z2JPJ4N4mVDu6pd/hr7widdCqbKekA53BXHoX7XhL9tmRmQ8kfmkaStBfla67QHhkchWYBQ==}
+
   '@digitalbazaar/http-client@1.2.0':
     resolution: {integrity: sha512-W9KQQ5pUJcaR0I4c2HPJC0a7kRbZApIorZgPnEDwMBgj16iQzutGLrCXYaZOmxqVLVNqqlQ4aUJh+HBQZy4W6Q==}
     engines: {node: '>=10.0.0'}
@@ -3234,6 +3343,17 @@ packages:
 
   '@digitalbazaar/security-context@1.0.1':
     resolution: {integrity: sha512-0WZa6tPiTZZF8leBtQgYAfXQePFQp2z5ivpCEN/iZguYYZ0TB9qRmWtan5XH6mNFuusHtMcyIzAcReyE6rZPhA==}
+
+  '@digitalbazaar/vc-status-list-context@3.1.1':
+    resolution: {integrity: sha512-cMVtd+EV+4KN2kUG4/vsV74JVsGE6dcpod6zRoFB/AJA2W/sZbJqR44KL3G6P262+GcAECNhtnSsKsTnQ6y8+w==}
+
+  '@digitalbazaar/vc-status-list@8.0.1':
+    resolution: {integrity: sha512-GOCXsOOnEtQnWvvpwU4EcrBjK+DrfD6ouLtlkiyvRuo8clIBs/5gsz8EWwMLtCrgIdcF6RwFs0dmkSKe9FSxAg==}
+    engines: {node: '>=18'}
+
+  '@digitalbazaar/vc@7.2.0':
+    resolution: {integrity: sha512-Fpa7MG+/pxwV0vJbstKJc1DLrVzFYz7mlqZfRMkFOodR0YvVp3GGdiybCKtj7oxv/cuskzuqB/MFmDhq8tEd9g==}
+    engines: {node: '>=18'}
 
   '@digitalcredentials/base58-universal@1.0.1':
     resolution: {integrity: sha512-1xKdJnfITMvrF/sCgwBx2C4p7qcNAARyIvrAOZGqIHmBaT/hAenpC8bf44qVY+UIMuCYP23kqpIfJQebQDThDQ==}
@@ -4522,12 +4642,21 @@ packages:
   '@ioredis/commands@1.2.0':
     resolution: {integrity: sha512-Sx1pU8EM64o2BrqNpEO1CNLtKQwyhuXuqyfH7oGKCk+1a33d2r5saW8zNwm3j6BTExtjrv2BxTgzzkMwts6vGg==}
 
+  '@ipld/dag-cbor@6.0.15':
+    resolution: {integrity: sha512-Vm3VTSTwlmGV92a3C5aeY+r2A18zbH2amehNhsX8PBa3muXICaWrN8Uri85A5hLH7D7ElhE8PdjxD6kNqUmTZA==}
+
   '@ipld/dag-cbor@7.0.3':
     resolution: {integrity: sha512-1VVh2huHsuohdXC1bGJNE8WR72slZ9XE2T3wbBBq31dm7ZBatmKLLxrB+XAqafxfRFjv08RZmj/W/ZqaM13AuA==}
 
   '@ipld/dag-cbor@9.0.3':
     resolution: {integrity: sha512-A2UFccS0+sARK9xwXiVZIaWbLbPxLGP3UZOjBeOMWfDY04SXi8h1+t4rHBzOlKYF/yWNm3RbFLyclWO7hZcy4g==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  '@ipld/dag-json@8.0.11':
+    resolution: {integrity: sha512-Pea7JXeYHTWXRTIhBqBlhw7G53PJ7yta3G/sizGEZyzdeEwhZRr0od5IQ0r2ZxOt1Do+2czddjeEPp+YTxDwCA==}
+
+  '@ipld/dag-pb@2.1.18':
+    resolution: {integrity: sha512-ZBnf2fuX9y3KccADURG5vb9FaOeMjFkCrNysB0PtftME/4iCTjxfaLoNq/IAh5fTqUOMXvryN6Jyka4ZGuMLIg==}
 
   '@ipld/dag-pb@4.0.8':
     resolution: {integrity: sha512-693AqMY2jvhe+w4jSwjnDrbhxIu39gm1H4f6/KD5gG+6VFMM6EXV7vq85BvEf8CRsnA0+auWfA29/S8gbWI0Ew==}
@@ -4670,6 +4799,185 @@ packages:
 
   '@lit-labs/ssr-dom-shim@1.2.0':
     resolution: {integrity: sha512-yWJKmpGE6lUURKAaIltoPIE/wrbY3TEkqQt+X0m+7fQNnAv0keydnYvbiJFP1PnMhizmIWRWOG5KLhYyc/xl+g==}
+
+  '@lit-protocol/access-control-conditions@2.2.63':
+    resolution: {integrity: sha512-TuppUsA3jJ9SbllW4dgn+XFoleTN8O2ZS7Uxpj3vFpK3gmyeiDutgsBRIa939WPgUN+2tuBNSZ48a0TLB3PRtA==}
+
+  '@lit-protocol/access-control-conditions@3.1.4':
+    resolution: {integrity: sha512-Oy1xbDgBHK00D+7G+D1Kchor1auXLzmPsH2BEBVYpTITuQ2VcQ6JQ54e+3pUzzp6wqie7RRfngorxo4az8DeNw==}
+
+  '@lit-protocol/access-control-conditions@6.11.5':
+    resolution: {integrity: sha512-ibtuAGilhgDBIMalsZFPcidzi1WdvMfHKjJqxastriESrBhIAipvWbe6XmDzerb9sRyBLivCDPyCc1cJqnO3Mw==}
+
+  '@lit-protocol/accs-schemas@0.0.19':
+    resolution: {integrity: sha512-O7hrDPUA6x5fgOx8HKRAV1k/8VMzwehfNHUwb2UGMbw4g3kKpokbR/ne7OPdIUYMgvRATc0WjL5gbh/w33pkOQ==}
+
+  '@lit-protocol/accs-schemas@0.0.3':
+    resolution: {integrity: sha512-hjdJzeHHRABnelu3dZVQFEJUVdtJ9bs7in6uknvWonhTgr4N2m4uMMmYSMGMLXFBpMC53F8V3iF47KxZllCHtQ==}
+
+  '@lit-protocol/auth-browser@2.2.63':
+    resolution: {integrity: sha512-irY2l7F3GJN4C+5eUd1n7Ig2iDSXMCuTOEy2/WBM6shZUKiaaVpnS2UKgzeKPBwbuj0zGLqaN74jXXhUW9C/iQ==}
+
+  '@lit-protocol/auth-browser@3.1.4':
+    resolution: {integrity: sha512-YF5Nqgz1yNX9IvVdfbmt7YrDRkM1JF3lcC1OjJy5L1Kfnolv3ktOhR3tXqZXKUb/z5m7Co/sS8BUnTB711p9Uw==}
+
+  '@lit-protocol/auth-browser@6.11.5':
+    resolution: {integrity: sha512-Udzha0aCnOrIoj3LW9ipIdTEmrztIRKOZ9ziOCdLs8l+wOwkEz7oDJ2u5TBO58I8z7K1VHVmU9qXlkkyCGoQcg==}
+
+  '@lit-protocol/auth-helpers@2.2.63':
+    resolution: {integrity: sha512-2U0IMy2lnLV4A9IZUPgEoF4U29ef5RR9kDDZ7+a6+hN6IjEUhLTGkRicMUNe+QEgb5G6CFOd4Ze0/1fkchFcQQ==}
+
+  '@lit-protocol/auth-helpers@3.1.4':
+    resolution: {integrity: sha512-Bg9SSosfS6uSvot8ewFRcTQm8rpTdOtCYXSrmIUcd7tb810F4FDslptlour+Q0fByCjIqFdOwipeznk4EDDjmw==}
+
+  '@lit-protocol/auth-helpers@6.11.5':
+    resolution: {integrity: sha512-OISAenlqu5GkgXDV5uerCojG2z9KJZr2uGG3aCzAb/YmdssaBb3OfvTBBbBZLKL7uNwzEtWLGRnvQHSrPMe/rQ==}
+
+  '@lit-protocol/bls-sdk@2.2.63':
+    resolution: {integrity: sha512-2ahRBjxpm3SrkhGeb/CULPapmFtayZMgEHwrO7CqPA0M7GrqWvAAg0JFhUlSEdos3/q/Kei7B+ohsG7xPoBOfQ==}
+
+  '@lit-protocol/bls-sdk@3.1.4':
+    resolution: {integrity: sha512-xYO/ae467yeX0bbyaRAwvYHNuPIoDcLL0na3xDASUI1wMmbi1ozmEepXqBiOfsA7sPKpiwqNOFNNYi46B65pYw==}
+
+  '@lit-protocol/bls-sdk@6.11.5':
+    resolution: {integrity: sha512-lfy662lFjL7fkEvYYfGJXe4UorbuKzyzORRecpTtHFX1rdFaUJW6RgxQj9G2hmYpo15ls/XSfWZiK/9WWhiDpw==}
+
+  '@lit-protocol/constants@2.2.63':
+    resolution: {integrity: sha512-YY2/ErJnosC8mwyBVfa6gVnHSF+2XMzoGAkFndBeb3rtanxN5JbrmBUGjkc1U1lo4NhmxhI2/inK84h637xypQ==}
+
+  '@lit-protocol/constants@3.1.4':
+    resolution: {integrity: sha512-3aXIuea9SB5UfRbVgn5CxFnDeQe9hnoYE8r0KMq71skKt7d4AavEmVm/kIzCR7dWibbnPLdlgqBVqrGRh3S9/g==}
+
+  '@lit-protocol/constants@6.11.5':
+    resolution: {integrity: sha512-dYn0K7n60UMd8/VGIHwHGlFngR0Lm9cVhaFb6jWU1RcDVBIstNju4ENFXoXBHifT3Bah4Vg+nIH89B7oAjO/Ww==}
+
+  '@lit-protocol/contracts-sdk@3.1.4':
+    resolution: {integrity: sha512-LZmq8xKXBZw5rrD6hEretX0ETVpDnwnJNLWh6pXCExUuefMgekGrhVCUsdBfzgdZMcj04Pi+GN7pfUd2+pg21Q==}
+
+  '@lit-protocol/contracts-sdk@6.11.5':
+    resolution: {integrity: sha512-z5jb1Xf3M/yAkSIqzoxGi7y4+TU/oZCGbLIlOp6ndxOw6cMhPvP+TisgnIVpQ681xxaymBUnBnTQG3zk38LQjw==}
+
+  '@lit-protocol/contracts@0.0.63':
+    resolution: {integrity: sha512-CAorNt72ybIY/g//dDeR837izNGuYQR99XwPSK2X2AJ6c+aZX1kdXCrOnxsbY40BzFrOk/dIFo+ymJ9E3qh48w==}
+    peerDependencies:
+      typescript: ^5.0.0
+
+  '@lit-protocol/core@2.2.63':
+    resolution: {integrity: sha512-jn1hIP4GRXuBsFmNYRosS/J6/Dw+1ASJM7F++aF8slMDowkOfw1BnHNf/+ZDvpFmBL/Qw+wo+mkah6YJlPVp4w==}
+
+  '@lit-protocol/core@3.1.4':
+    resolution: {integrity: sha512-4GSeeLVcv53A0Ry20cwbgDP4fP+YijQphdcBKFgi4WO8Rnrug4bYJyTDlmgmmQuIMO/IG/JRh6ls7h0a2WwAkA==}
+
+  '@lit-protocol/core@6.11.5':
+    resolution: {integrity: sha512-nkDjXs2QB4Mb1tYUWrv8l1Z6cMKUeKJCqKbtuqnxAuDjJvJzOndCwsHM0C9h3J7mU6qmtWboXTkSLys3EUUN2g==}
+
+  '@lit-protocol/crypto@2.2.63':
+    resolution: {integrity: sha512-ZBcp1wERw3B3HI/l8RVxfMhNVK4dQtnltsUiWDPspqCRHuAxdtHlyeX3sknu2bM+gp2xeTsS/SGH2m+RUSLQzw==}
+
+  '@lit-protocol/crypto@3.1.4':
+    resolution: {integrity: sha512-qZXU0aAbhC4EMCOm0U2gRfaJVWrsyGxd7S/+qIFYZgZ68FiQRblbQGZx871oI3Aab56jhP1rAkpaPU/Hhc6rng==}
+
+  '@lit-protocol/crypto@6.11.5':
+    resolution: {integrity: sha512-Z5/TfFKa1kn1V0H/d6djiRObKaCDcsQACeqBrPSLhpQc0Lgi1ONhOfjJMXqgCFUBvQAm9kyLUY5XoniX7is7ow==}
+
+  '@lit-protocol/ecdsa-sdk@2.2.63':
+    resolution: {integrity: sha512-4889MRHYJlQPe7iLv9NDNzJG6UrGHvmrorYrY35nfApCaMS+nJoZ4Ghbyyjo1HRgncp+Qm9px0fkRCZMj+tCsQ==}
+
+  '@lit-protocol/ecdsa-sdk@3.1.4':
+    resolution: {integrity: sha512-zMUY8EsecSVoZP478ScYtO++UOT1IxXVDFSR2dX9JOoy1MdHNeglXEd2u9BeNgVebipx3jw9RtJJ9ZWicOVA5A==}
+
+  '@lit-protocol/ecdsa-sdk@6.11.5':
+    resolution: {integrity: sha512-HKC9BJJ5wa7EUWz1Gndt0MbspYiejYO/I+pE8/zDFyJgL4odyI8bWfoYOp3BzlFRwtE7YuB7dFxJUzQ/egLjdw==}
+
+  '@lit-protocol/encryption@2.2.63':
+    resolution: {integrity: sha512-SP1QhPDaHK5Muxh2TWDN2wLrKAO3xDtnS2fKxljUrJgGaMmo/LrHM4DVQEEw8YxjO1+9OkuTdBJPEc30zZgI3A==}
+
+  '@lit-protocol/encryption@3.1.4':
+    resolution: {integrity: sha512-Cc9X7TXXeoSpeMWBA+xm3u+9MxJBGzQ/sm7tDdwnjdV1P++jI5+4S+tx7k1luMbh3vk70nScdUqVtiEkgzGFIg==}
+
+  '@lit-protocol/encryption@6.11.5':
+    resolution: {integrity: sha512-D0DABE6yNG5P5yakdmZUOOHzKr3NSRQXmfbq1nfNBpB4pkJQA24eBp+c2GMPHuey74UOwBJm770GU03neq0vVg==}
+
+  '@lit-protocol/lit-node-client-nodejs@2.2.63':
+    resolution: {integrity: sha512-/RercEUROJe3aZb4d/yaZ2y9sHmZ+/6Q3P7EBkt1yOekAcFyuNZA8kN/lOzHs+auJNPUsBU8pcqcVFUdRVMaKA==}
+
+  '@lit-protocol/lit-node-client-nodejs@3.1.4':
+    resolution: {integrity: sha512-CGGtNpgEHfUPiAYC2tHYgMgG2QphK5gB1pCxPcqqXf3TH+2lwXXKY9RzZx4QtQl1qgvL5vniQONWk/GJobwuFQ==}
+
+  '@lit-protocol/lit-node-client-nodejs@6.11.5':
+    resolution: {integrity: sha512-xkd+Ym7uYpvR3HsPjxS7y3mW/wKtIXAegD2wYC0T6hzb0MicnFVrca7UWS3OldrxDad2RwnepVycijPWBgfNVQ==}
+
+  '@lit-protocol/lit-node-client@2.2.63':
+    resolution: {integrity: sha512-k3LiPutKVGpdEvnKAG7mm2enL+rt8hmC3ZGUZ9iE3d2vWr2NBA5n+79OV0zDrMw+ZB96Wh/Q/Io37J+wf6gyvA==}
+
+  '@lit-protocol/lit-node-client@3.1.4':
+    resolution: {integrity: sha512-LUp+4bUDUh0YytpvAUEbzaiC7A2Uxo8AO89RcLwnFt4LAe0X+8UGHIoRdP+hWjiqxMkoGOyuUa25m4uayewSsA==}
+
+  '@lit-protocol/lit-node-client@6.11.5':
+    resolution: {integrity: sha512-ZlLr8KdD1DATtVxfak8T5C00XkgeKyj5FmcNSeGldxEGaOZkfXkIhajuHotvNyQrD3P2I/41UO+At3ghi96ebQ==}
+
+  '@lit-protocol/lit-third-party-libs@2.2.63':
+    resolution: {integrity: sha512-+ifxNv958O9dB8uHCrsFR/hsCnLqqNab5HYnU0JL61KFKEeprREHCXvJt1pJWGdZ3UPCABsk3UyBq8lmJsQoNg==}
+
+  '@lit-protocol/lit-third-party-libs@3.1.4':
+    resolution: {integrity: sha512-WPaQJgiIxlELacnCWvKjWHKilw0AyM7UpIo3Mgi/slxbclgiNlUOFqxzqNzEjIaQvuvOsYzOOw8JJOTUPLLMXg==}
+
+  '@lit-protocol/logger@3.1.4':
+    resolution: {integrity: sha512-YATxPh1hyXqg5DJgn9XqDvMJQT/jztJhPVyz1bNf08np5PUw+pcWBpqhp16F1rW15j6zJJX+oEorvq6Ts5a5Tw==}
+
+  '@lit-protocol/logger@6.11.5':
+    resolution: {integrity: sha512-YgtO+n8qjLhbDCgvGIGVBJqlNj6oib+VLLM9m5k2nZpkfMBipRBw/pMCBu3zvwLcMGJuDpUaF1eEocrtRYO5+A==}
+
+  '@lit-protocol/misc-browser@2.2.63':
+    resolution: {integrity: sha512-i2ANHRb8VqlkHMljJpjlYlhgfC7xKf2t1ivBcHU9zTJaHD5lBDTYb1bZW+oWJ6y02YkML2z3WGHDLKjXiHxzog==}
+
+  '@lit-protocol/misc-browser@3.1.4':
+    resolution: {integrity: sha512-rKyp23XztE8GKVNY+zwSNXuQslAUku6OnUFC1MghKHub4Dz9xIymXvQ+Ytq4NkScccGpIt7pXol/tBVDOKKkjQ==}
+
+  '@lit-protocol/misc-browser@6.11.5':
+    resolution: {integrity: sha512-vaTkifWM6/j5sKXlVRN5wSPgkc1DhN+uKJqWgjyVcuvSjwjKrqe6P984Um0FUWu3PPaDW76Anve9uJHcPWzCUg==}
+
+  '@lit-protocol/misc@2.2.63':
+    resolution: {integrity: sha512-BZy8tpA+zXcCD94vwdr3yAY6TxvBepbPJOguC9E/Tq7sAdmkJupkJpLNVocbPw0X97j0agwoqryN8TGY31YE+g==}
+
+  '@lit-protocol/misc@3.1.4':
+    resolution: {integrity: sha512-QdrpP2LJQwpunPs0m1/MK12451w+KEn0YdFCjBxgbA9J/cvX2yH+YQjWmCNIO5Vd1Hle9MhP66S7F9QovF00pg==}
+
+  '@lit-protocol/misc@6.11.5':
+    resolution: {integrity: sha512-MNw4E0arjDm0hX8V9DIcU7NTwoL0qNnxsdUumh6MoUnckcmdcMQjrvzFaO342edgj93YP5b8iAxrrkIUhj68Bw==}
+
+  '@lit-protocol/nacl@2.2.63':
+    resolution: {integrity: sha512-4Xfk9ClriH2Gl6OmElmFqgJgMv2GppaHde4iFWECq1FQrqo+EQyQaxEDrdkbv1xBRq4fxQngPq+tjfQXIwF4Iw==}
+
+  '@lit-protocol/nacl@3.1.4':
+    resolution: {integrity: sha512-CPV8JhN7GnAabV3PY5+HM44Y1L0SaoPHH3nUJ4fehGs8cQa63qQ8M0cOihR1lByS75u+tBTNIdNIAsuY0dw1dA==}
+
+  '@lit-protocol/nacl@6.11.5':
+    resolution: {integrity: sha512-g/s2FKmjQDN5rcfrXNKtLTO3K9/uMLeJc14pdq8Q/fCVOoNoXgl8X40bA/tao7MG3J1bq61n6o9keAE5gQUD4g==}
+
+  '@lit-protocol/sev-snp-utils-sdk@3.1.4':
+    resolution: {integrity: sha512-YK8o+h0MbljDlJ9ZD33bELHK1DXD0iobdfAIkOa2hhPTsXR/PMdm+Y7L6O0ZQAsKDynK7958NdV3A/vqXEr3xQ==}
+
+  '@lit-protocol/sev-snp-utils-sdk@6.11.5':
+    resolution: {integrity: sha512-B6o6o6cucWNO7y5mqhIM4k9sOs5VRO+h6dTODp0RK3IPlobPiK46oKx3DG6gAEK2uNDUI3YERCM++0LLkVfcEw==}
+
+  '@lit-protocol/types@2.2.63':
+    resolution: {integrity: sha512-Ky3nhjvZuuJMRUXQBa4pwthVozL2mDEj/qTYDYOfmOOzco0QW9vppGMsyNdro48+4rt7yWZLNvSSfRcXXeMvcw==}
+
+  '@lit-protocol/types@3.1.4':
+    resolution: {integrity: sha512-R2V/3+DLLhrriweTc1n032PqB0TszYnNJs03sEuvIy2hkIoTunwUHdLKw5glaRRzTIZRimUBmJgo/ZLQa2pkiQ==}
+
+  '@lit-protocol/types@6.11.5':
+    resolution: {integrity: sha512-oaJLtsjp2gW2IItSwUi7PUwD0nPGbs3nKNOFHjnNFGQeL1eT40G53CAkvAc9dJ8+YENzmuYEYa4e+5fCGAszVQ==}
+
+  '@lit-protocol/uint8arrays@2.2.63':
+    resolution: {integrity: sha512-/pY+hl3kbfsU0aLT1Aaf3NHb9+yYqAoskFeYNfAY7FwrPVw2w3v4k21m/SNHZ8Rx1LpyOpvsItNTJfTntm0N8Q==}
+
+  '@lit-protocol/uint8arrays@3.1.4':
+    resolution: {integrity: sha512-un9+5yuq8natXvXfIufwMziSnYmogmiVwAdnOTkR/1ZR51g0hk0RXOuA6BnCHXAfgldwkXNr/wJaRzrqdVjf+g==}
+
+  '@lit-protocol/uint8arrays@6.11.5':
+    resolution: {integrity: sha512-pop1E+Iua8ugVECFqCyfAlslXxogNj6fwd8EIbS8WIXJfQvPPo0SmXK3PNU9m7yBfPgSngBwB1eQrkMrN1ZXFQ==}
 
   '@lit/reactive-element@1.6.3':
     resolution: {integrity: sha512-QuTgnG52Poic7uM1AN5yJ09QMe0O28e10XzSvWDz02TJiiKee4stsiownEIadWm8nYzyDAyT+gKzUoZmiWQtsQ==}
@@ -4977,6 +5285,10 @@ packages:
   '@multiformats/base-x@4.0.1':
     resolution: {integrity: sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw==}
 
+  '@multiformats/murmur3@2.1.8':
+    resolution: {integrity: sha512-6vId1C46ra3R1sbJUOFCZnsUIveR9oF20yhPmAFxPm0JfrX3/ZRCgP3YDrBzlGoEppOXnA9czHeYc0T9mB6hbA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   '@next/env@13.4.13':
     resolution: {integrity: sha512-fwz2QgVg08v7ZL7KmbQBLF2PubR/6zQdKBgmHEl3BCyWTEDsAQEijjw2gbFhI1tcKfLdOOJUXntz5vZ4S0Polg==}
 
@@ -5039,6 +5351,7 @@ packages:
 
   '@nextui-org/accordion@2.0.32':
     resolution: {integrity: sha512-iwvEd89SdOrtCxeX2Pq44wmgFm6a01sCq79BgCKuqMcsCFekZ5/yQu09R3kBB6Kne4ghZWF6MXgmzOgbS04atg==}
+    deprecated: This package has been deprecated. Please use @heroui/accordion instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5054,6 +5367,7 @@ packages:
 
   '@nextui-org/autocomplete@2.0.16':
     resolution: {integrity: sha512-cVkFTiiM6Io7XPKMMdNZdTg9OpC/SVOsO48RrbxIv9Nl2HzvQYadhsiYett3skSMTy4u3Az8FJPUp+ql0GmxxA==}
+    deprecated: This package has been deprecated. Please use @heroui/autocomplete instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5063,6 +5377,7 @@ packages:
 
   '@nextui-org/avatar@2.0.27':
     resolution: {integrity: sha512-rmEWhzg7bHOYWCvcFWBjex80aRtnLE7QyHWTHr9+KtOQRJRtv33Kxy5JfDcCQ6vKBz/ZPAWJ76ftUaba3yvXjQ==}
+    deprecated: This package has been deprecated. Please use @heroui/avatar instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5071,6 +5386,7 @@ packages:
 
   '@nextui-org/badge@2.0.27':
     resolution: {integrity: sha512-7JH8X7F4FvsPjygToTId87/syh0ZPS6GK8z3zCZHu7zgA10FrwbCyQGuTpznF2GAnmtW3DxTWpemOOJD0dMJbQ==}
+    deprecated: This package has been deprecated. Please use @heroui/badge instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5078,6 +5394,7 @@ packages:
 
   '@nextui-org/breadcrumbs@2.0.7':
     resolution: {integrity: sha512-4xD3hUy5QFtYSZWxjY8Cprq4BpSPfqkR9RyVmG9q5MCeJ8zJQTZlEZ1VCZjnwx4Mtif4kDxAgEm/eBhn6dW7mA==}
+    deprecated: This package has been deprecated. Please use @heroui/breadcrumbs instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5086,6 +5403,7 @@ packages:
 
   '@nextui-org/button@2.0.31':
     resolution: {integrity: sha512-EqrmTLhJaIFqDCK247XHuEE0c10A1mnRpIoMEgwP5GUjAFC/5itpdU80zRDi4zWXUaI6ppaVpZqWnDOCK5Qvwg==}
+    deprecated: This package has been deprecated. Please use @heroui/button instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5095,6 +5413,7 @@ packages:
 
   '@nextui-org/calendar@2.0.4':
     resolution: {integrity: sha512-B1OqFBt9Z8jh42qPW6u5W0fsyf1iYs2d1hdhHfVEvFgK7E1KoNaVe03pwZsZV/tYTW/Mh5zSuNwWhhWxphzrHA==}
+    deprecated: This package has been deprecated. Please use @heroui/calendar instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.0.0'
@@ -5103,6 +5422,7 @@ packages:
 
   '@nextui-org/card@2.0.28':
     resolution: {integrity: sha512-Vwa7Poi1kxqjnTWQS9FAGlQw301RqkMlY5cnYQCGeKNbFX+y6u1MlqTSi8ed6RqmdjO23j1zG2+XlBieFyJ9Mg==}
+    deprecated: This package has been deprecated. Please use @heroui/card instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5112,6 +5432,7 @@ packages:
 
   '@nextui-org/checkbox@2.0.29':
     resolution: {integrity: sha512-Ed1ahtrFoewt61TPi3aDFZAeA2+Dn+D4A798A2OPBPMHLe70xBPL84Vi35okeY3bzUdBwWQKLMGXbz9nM26sZA==}
+    deprecated: This package has been deprecated. Please use @heroui/checkbox instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5120,6 +5441,7 @@ packages:
 
   '@nextui-org/chip@2.0.28':
     resolution: {integrity: sha512-oD28KZx+PuaWkHlizvMgOAxIkL9cblwun0IhqEztKcR2DMRVdH/4r8/Zdo6QQFDhXlUU0Ub5+WUOyHndwNj0pg==}
+    deprecated: This package has been deprecated. Please use @heroui/chip instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5128,6 +5450,7 @@ packages:
 
   '@nextui-org/code@2.0.27':
     resolution: {integrity: sha512-gDK48LMNSgQIeUs5WZ53s/hRqDfTMuDdDNgQcmt0bRWMlUC2BTuBfQGzK4y9wbJA9mlWocia7ZDWRWyJrB4vjQ==}
+    deprecated: This package has been deprecated. Please use @heroui/code instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5135,6 +5458,7 @@ packages:
 
   '@nextui-org/date-input@2.0.3':
     resolution: {integrity: sha512-7WMJGptHHl+P0LpKk3a7e/Dj86Np66RGLVzWWlFipe7hrg+wJCdkuWCyj6V9mNgH/sdkVKhfkGYT2MogNbOhdA==}
+    deprecated: This package has been deprecated. Please use @heroui/date-input instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.0.0'
@@ -5143,6 +5467,7 @@ packages:
 
   '@nextui-org/date-picker@2.0.7':
     resolution: {integrity: sha512-03Jys6JMthgX1BMW9R1MKPkHkoetXf4bYZRETAXU5Y9cY1TcosY0FiDEwAUCjlusYOq2UWMRYH4q83tCmir6ag==}
+    deprecated: This package has been deprecated. Please use @heroui/date-picker instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.0.0'
@@ -5151,6 +5476,7 @@ packages:
 
   '@nextui-org/divider@2.0.27':
     resolution: {integrity: sha512-530oEHonzaxKxspoaKnBFJ4InGqXv2FgOYzEPAMWoMmLb4/zp7e5lRipFKqRsN+zdwIkRNH6c0VJmHfyWI+bUg==}
+    deprecated: This package has been deprecated. Please use @heroui/divider instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5158,6 +5484,7 @@ packages:
 
   '@nextui-org/dropdown@2.1.23':
     resolution: {integrity: sha512-4wAzUbKztvuzzuJcLuDKhvnxB++EQ2aATbCdnfcBA5IyBxj6k4lbalgmSQxtx6D4dm5iJeiOWCJHRZgsIqkxRg==}
+    deprecated: This package has been deprecated. Please use @heroui/dropdown instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5174,6 +5501,7 @@ packages:
 
   '@nextui-org/image@2.0.27':
     resolution: {integrity: sha512-EJa1bsZL8zsnTOVd+ZY04ldBz177CO/igz16rpRjo1KPMDX0fxlcjUbUopMfujIASytA68Yq4U1rxfO/xJthuQ==}
+    deprecated: This package has been deprecated. Please use @heroui/image instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5182,6 +5510,7 @@ packages:
 
   '@nextui-org/input@2.1.21':
     resolution: {integrity: sha512-jwTD4RnpTuieSuLOYqW7Dw2To6E9OVJtcyRBYNIT6GaejT3YG4qaST7BMKz0pJW6mgF9M+pDeKcdOvOqEbOoDg==}
+    deprecated: This package has been deprecated. Please use @heroui/input instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5190,6 +5519,7 @@ packages:
 
   '@nextui-org/kbd@2.0.28':
     resolution: {integrity: sha512-raH2Nw+wAHO54swTduLLs/Vdg2/mbMHEe0Y7ud6D13lPexWHVfxUzt7C39/9y8nKh0SpgOkcWV+EmQBydLAI7A==}
+    deprecated: This package has been deprecated. Please use @heroui/kbd instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5197,6 +5527,7 @@ packages:
 
   '@nextui-org/link@2.0.29':
     resolution: {integrity: sha512-OfOi7GLj3apimwAsAXTRZ8/B0tWvx/yXLZFtEe9676+tlLND1nfmWyBHdDIx5WMMiLc3Q1M3FkNrZvigeKQIbQ==}
+    deprecated: This package has been deprecated. Please use @heroui/link instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5205,6 +5536,7 @@ packages:
 
   '@nextui-org/listbox@2.1.19':
     resolution: {integrity: sha512-9qQs9KwdDHZ3VaSz4SkYcqn8onuSMCiZElta1vyqJGMWW6JYjJ4DtUOiyqwJdzZOQLIlxazT+GCWjjFUZwFZlQ==}
+    deprecated: This package has been deprecated. Please use @heroui/listbox instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5213,6 +5545,7 @@ packages:
 
   '@nextui-org/menu@2.0.22':
     resolution: {integrity: sha512-zU1MbyDPk0QNAVZUSDJSMmdVxpFzWHyiLqOtS+b+kZLdn0va+QBR6LPj237PhyQueChNyz/y8eDDbJ0D6bWf/g==}
+    deprecated: This package has been deprecated. Please use @heroui/menu instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5221,6 +5554,7 @@ packages:
 
   '@nextui-org/modal@2.0.33':
     resolution: {integrity: sha512-YCgWUMNiVMXAgd6SmU4yH7Ifrz+cmtlF2sK9DBL8kaIZtqAjuhPQj0uQnetvXpY649vomJWVdh9QYHNfD1Jv1Q==}
+    deprecated: This package has been deprecated. Please use @heroui/modal instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5230,6 +5564,7 @@ packages:
 
   '@nextui-org/navbar@2.0.30':
     resolution: {integrity: sha512-Iaw3BU0gdX14nBtZUUFRnsXodnCe1Sbsv9Xk7OI44p+KbOhySgfcjf4iFcXM0vfTOMlOkBSsUzR9bt+/69G5pw==}
+    deprecated: This package has been deprecated. Please use @heroui/navbar instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5239,6 +5574,7 @@ packages:
 
   '@nextui-org/pagination@2.0.30':
     resolution: {integrity: sha512-tdlSbNTpqr+aww8h9+7d2Iu0ZX6GGtREeVAbf2+jr5j7VF/VVMVm2eaLJ4m1vw7VQIrEMwKNrcP8QCMMT0a+SQ==}
+    deprecated: This package has been deprecated. Please use @heroui/pagination instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5247,6 +5583,7 @@ packages:
 
   '@nextui-org/popover@2.1.21':
     resolution: {integrity: sha512-Loa6eoAYW0DacDIW+/SC//0LhDDAMnUcd8R9axXtKd00N0Zgnj3YpUJoyLRYvwl5I/FWwV1nCOAvndzW6JJvpQ==}
+    deprecated: This package has been deprecated. Please use @heroui/popover instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5256,6 +5593,7 @@ packages:
 
   '@nextui-org/progress@2.0.28':
     resolution: {integrity: sha512-3Wp6mUeKzw0onLB7/JR1HI3+Y4zf0immVnQp3TYr2zvM5PLAy6RXKtACEGkJanBPfvx4tv3YAIF3419WMvmniw==}
+    deprecated: This package has been deprecated. Please use @heroui/progress instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5264,6 +5602,7 @@ packages:
 
   '@nextui-org/radio@2.0.28':
     resolution: {integrity: sha512-h8SSQTDj0NzB13r77RrcEDuWNSpE00ioO7GJKTROd09YQSmck/AID1+ktsDMRQYjoPMPJ7vgwJHuRoKIjXn1CQ==}
+    deprecated: This package has been deprecated. Please use @heroui/radio instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5288,6 +5627,7 @@ packages:
 
   '@nextui-org/ripple@2.0.28':
     resolution: {integrity: sha512-tAxuPjVncx6rSzdHqcFGiprlUo7p+tkTf0c9RMC47DtgIG1DLhFVr0z6QkggmLd1Tgwcj4a3Oyj/PAQMDRxswg==}
+    deprecated: This package has been deprecated. Please use @heroui/ripple instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5297,6 +5637,7 @@ packages:
 
   '@nextui-org/scroll-shadow@2.1.16':
     resolution: {integrity: sha512-QkOHNFQqEdfSj6iAKd4SusZpmyaJcBFCvx4zLLrWCXGS0+0KWvuaq/dOE8PXSPo4vts4TGDQp6qQGhk0BFvttg==}
+    deprecated: This package has been deprecated. Please use @heroui/scroll-shadow instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5305,6 +5646,7 @@ packages:
 
   '@nextui-org/select@2.1.27':
     resolution: {integrity: sha512-SLEOir+I09y9wA1reIJRefovyR48Pn+L6oMIiZqYCA0ndGnz3K1g2gsSZ6fyCb9obwZvjzFGvIsrYkW0btUzlA==}
+    deprecated: This package has been deprecated. Please use @heroui/select instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5322,6 +5664,7 @@ packages:
 
   '@nextui-org/skeleton@2.0.27':
     resolution: {integrity: sha512-AolxdzJ4xCyb7i2DwZ1iQGSaLGUBYh/rorO8llBqsXDpvhBANcFF3DbRO3kQ+EVGr5AEbEeurd3RabC2F6wVDA==}
+    deprecated: This package has been deprecated. Please use @heroui/skeleton instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5329,6 +5672,7 @@ packages:
 
   '@nextui-org/slider@2.2.9':
     resolution: {integrity: sha512-y/Oxhl1OkY7amgYpHZwCF4dF6Uop0Pb+k6m6CNCeXIBL3KFT1Hw9yd17NrV05BekA1llfJrVHEvzneBuTTbbbA==}
+    deprecated: This package has been deprecated. Please use @heroui/slider instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5337,6 +5681,7 @@ packages:
 
   '@nextui-org/snippet@2.0.35':
     resolution: {integrity: sha512-2GYxzt6ZBqgEn6XYgi+uU8YMPfMPCAORMXiw/Q+QTuoLQPgKFqsjnQKV7FI581Dax61mIMI5QL5WsQ0oG6PtFw==}
+    deprecated: This package has been deprecated. Please use @heroui/snippet instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5346,6 +5691,7 @@ packages:
 
   '@nextui-org/spacer@2.0.27':
     resolution: {integrity: sha512-2zYe6PR7Mk4xQpzEhAAkZ8fBp75h7XhgSB7u1aiqW2hJzcuD82hn1SLoUacrYJeO/FBO5UJKQmc8LT63JtuzWQ==}
+    deprecated: This package has been deprecated. Please use @heroui/spacer instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5353,6 +5699,7 @@ packages:
 
   '@nextui-org/spinner@2.0.28':
     resolution: {integrity: sha512-hlixGubd91KFSHIjwE0/vLmkSOtUwl56uFrsHBred2pqq8/1CAVlN7aINwoUotZRc5W0T7lyEQGvf88t0Dd3CA==}
+    deprecated: This package has been deprecated. Please use @heroui/spinner instead.
     peerDependencies:
       '@nextui-org/theme': '>=2.1.0'
       react: '>=18'
@@ -5360,6 +5707,7 @@ packages:
 
   '@nextui-org/switch@2.0.28':
     resolution: {integrity: sha512-cogzyB7Ng95WP/neMBWgOLRkw2GC/qLQoW0gTuuT53lTEnAtatFikNoL30CyA/EZzz7YsUjLH2W+9kBiZLtITQ==}
+    deprecated: This package has been deprecated. Please use @heroui/switch instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5381,6 +5729,7 @@ packages:
 
   '@nextui-org/table@2.0.33':
     resolution: {integrity: sha512-mUqGGWCoEo5z49s60IrVnBDcSgT8K2T5+x5qqmk30v09B6s5c8dqyL7NAC+pk7BayHqr5xEW42EqMbRKmVvtCw==}
+    deprecated: This package has been deprecated. Please use @heroui/table instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5389,6 +5738,7 @@ packages:
 
   '@nextui-org/tabs@2.0.29':
     resolution: {integrity: sha512-RthZ+lNyXQ3CNXMRiQdQMGGsWJurS7ESrhowLRtTiDOPYhnJxAMqrqzI3k8ZgDIBirC/1zEoOdn89oqd2Pa5gw==}
+    deprecated: This package has been deprecated. Please use @heroui/tabs instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5403,6 +5753,7 @@ packages:
 
   '@nextui-org/tooltip@2.0.33':
     resolution: {integrity: sha512-WUpBuoZ1ya2iD9EI2d/E58BpPrRJQ2NDnpIU6RjwWe/MGqtxf3oJVQZd6kKpgaD8eB6P3OSiFTwTUK7+AoLmDQ==}
+    deprecated: This package has been deprecated. Please use @heroui/tooltip instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5510,6 +5861,7 @@ packages:
 
   '@nextui-org/user@2.0.28':
     resolution: {integrity: sha512-1WaAZSIzgRMaA+2+BACelxIE4YvPN6MFW+I3SvODwn98aju1yU485akxjenc7XM/5CC6TGZDAXiFz2VcEFIcZA==}
+    deprecated: This package has been deprecated. Please use @heroui/user instead.
     peerDependencies:
       '@nextui-org/system': '>=2.0.0'
       '@nextui-org/theme': '>=2.1.0'
@@ -5522,6 +5874,10 @@ packages:
   '@noble/ciphers@0.5.1':
     resolution: {integrity: sha512-aNE06lbe36ifvMbbWvmmF/8jx6EQPu2HVg70V95T+iGjOuYwPpAccwAQc2HlXO2D0aiQ3zavbMga4jjWnrpiPA==}
 
+  '@noble/ciphers@1.3.0':
+    resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
+    engines: {node: ^14.21.3 || >=16}
+
   '@noble/curves@1.2.0':
     resolution: {integrity: sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==}
 
@@ -5533,6 +5889,10 @@ packages:
 
   '@noble/curves@1.6.0':
     resolution: {integrity: sha512-TlaHRXDehJuRNR9TfZDNQ45mMEd5dwUwmicsafcIX4SsNiqnCHKjE/1alYPd/lDRVhxdhUAlv8uEhMCI5zjIJQ==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/curves@1.9.7':
+    resolution: {integrity: sha512-gbKGcRUYIjA3/zCCNaWDciTMFI0dCkvou3TL8Zmy5Nc7sJ47a0jtOeZoTaMxkuqRo9cRhjOdZJXegxYE5FN/xw==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/ed25519@1.7.3':
@@ -5559,6 +5919,10 @@ packages:
 
   '@noble/hashes@1.5.0':
     resolution: {integrity: sha512-1j6kQFb7QRru7eKN3ZDvRcP13rugwdxZqCjbiAVZfIJwgj2A65UmT4TgARXGlXgnRkORLTDTrO19ZErt7+QXgA==}
+    engines: {node: ^14.21.3 || >=16}
+
+  '@noble/hashes@1.8.0':
+    resolution: {integrity: sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==}
     engines: {node: ^14.21.3 || >=16}
 
   '@noble/secp256k1@1.7.1':
@@ -5805,6 +6169,36 @@ packages:
 
   '@polka/url@1.0.0-next.25':
     resolution: {integrity: sha512-j7P6Rgr3mmtdkeDGTe0E/aYyWEWVtc5yFXtHCRHs28/jptDEWfaVOc5T7cblqy1XKPPfCxJc/8DwQ5YgLOZOVQ==}
+
+  '@protobufjs/aspromise@1.1.2':
+    resolution: {integrity: sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==}
+
+  '@protobufjs/base64@1.1.2':
+    resolution: {integrity: sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==}
+
+  '@protobufjs/codegen@2.0.4':
+    resolution: {integrity: sha512-YyFaikqM5sH0ziFZCN3xDC7zeGaB/d0IUb9CATugHWbd1FRFwWwt4ld4OYMPWu5a3Xe01mGAULCdqhMlPl29Jg==}
+
+  '@protobufjs/eventemitter@1.1.0':
+    resolution: {integrity: sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==}
+
+  '@protobufjs/fetch@1.1.0':
+    resolution: {integrity: sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==}
+
+  '@protobufjs/float@1.0.2':
+    resolution: {integrity: sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==}
+
+  '@protobufjs/inquire@1.1.0':
+    resolution: {integrity: sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==}
+
+  '@protobufjs/path@1.1.2':
+    resolution: {integrity: sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==}
+
+  '@protobufjs/pool@1.1.0':
+    resolution: {integrity: sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==}
+
+  '@protobufjs/utf8@1.1.0':
+    resolution: {integrity: sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==}
 
   '@radix-ui/primitive@1.0.1':
     resolution: {integrity: sha512-yQ8oGX2GVsEYMWGxcovu1uGWPCxV5BFfeeYxqPmuAzUyLT9qmaMXSAhXpb0WrspIeqYzdJpkh2vHModJPgRIaw==}
@@ -6840,6 +7234,9 @@ packages:
   '@scure/base@1.1.9':
     resolution: {integrity: sha512-8YKhl8GHiNI/pU2VMaofa2Tor7PJRAjwQLBBuilkJ9L5+13yVbC7JO/wS7piioAvPSwR3JKM1IJ/u4xQzbcXKg==}
 
+  '@scure/base@2.0.0':
+    resolution: {integrity: sha512-3E1kpuZginKkek01ovG8krQ0Z44E3DHPjc5S2rjJw9lZn3KSQOs8S7wqikF/AH7iRanHypj85uGyxk0XAyC37w==}
+
   '@scure/bip32@1.3.2':
     resolution: {integrity: sha512-N1ZhksgwD3OBlwTv3R6KFEcPojl/W4ElJOeCZdi+vuI5QmTFwLq3OFf2zd2ROpKvxFdgZ6hUpb0dx9bVNEwYCA==}
 
@@ -6991,6 +7388,9 @@ packages:
   '@sphereon/ssi-types@0.22.0':
     resolution: {integrity: sha512-YPJAZlKmzNALXK8ohP3ETxj1oVzL4+M9ljj3fD5xrbacvYax1JPCVKc8BWSubGcQckKHPbgbpcS7LYEeghyT9Q==}
 
+  '@spruceid/siwe-parser@1.1.3':
+    resolution: {integrity: sha512-oQ8PcwDqjGWJvLmvAF2yzd6iniiWxK0Qtz+Dw+gLD/W5zOQJiKIUXwslHOm8VB8OOOKW9vfR3dnPBhHaZDvRsw==}
+
   '@spruceid/siwe-parser@2.1.0':
     resolution: {integrity: sha512-tFQwY2oQLa4qvHE6npKsVgVdVLQOCGP1zJM3yjZOHut43LqCwdSwitZndFLrJHZLpqru9FnmYHRakvsPvrI+qA==}
 
@@ -7012,6 +7412,9 @@ packages:
   '@stablelib/binary@1.0.1':
     resolution: {integrity: sha512-ClJWvmL6UBM/wjkvv/7m5VP3GMr9t0osr4yVgLZsLCOz4hGN9gIAFEqnJ0TsSMAN+n840nf2cHZnA5/KFqHC7Q==}
 
+  '@stablelib/binary@2.0.1':
+    resolution: {integrity: sha512-U9iAO8lXgEDONsA0zPPSgcf3HUBNAqHiJmSHgZz62OvC3Hi2Bhc5kTnQ3S1/L+sthDTHtCMhcEiklmIly6uQ3w==}
+
   '@stablelib/blockcipher@1.0.1':
     resolution: {integrity: sha512-4bkpV8HUAv0CgI1fUqkPUEEvv3RXQ3qBkuZaSWhshXGAz1JCpriesgiO9Qs4f0KzBJkCtvcho5n7d/RKvnHbew==}
 
@@ -7030,8 +7433,14 @@ packages:
   '@stablelib/ed25519@1.0.3':
     resolution: {integrity: sha512-puIMWaX9QlRsbhxfDc5i+mNPMY+0TmQEskunY1rZEBPi1acBCVQAhnsk/1Hk50DGPtVsZtAWQg4NHGlVaO9Hqg==}
 
+  '@stablelib/ed25519@2.0.2':
+    resolution: {integrity: sha512-d/lJ5sgzhtmpMIbKFWfev+i6WebBdIzzBpMzXtZdvUijoksjXosYFNqytoMj7cRshNj+/XTLYnnVMdZfd+penw==}
+
   '@stablelib/hash@1.0.1':
     resolution: {integrity: sha512-eTPJc/stDkdtOcrNMZ6mcMK1e6yBbqRBaNW55XA1jU8w/7QdnCF0CmMmOD1m7VSkBR44PWrMHU2l6r8YEQHMgg==}
+
+  '@stablelib/hash@2.0.0':
+    resolution: {integrity: sha512-u3WPSqGido8lwJuMcrBgM5K54LrPGhkWAdtsyccf7dGsLixAZUds77zOAbu7bvKPwQlmoByH0txBi5rTmEKuHg==}
 
   '@stablelib/hkdf@1.0.1':
     resolution: {integrity: sha512-SBEHYE16ZXlHuaW5RcGk533YlBj4grMeg5TooN80W3NpcHRtLZLLXvKyX0qcRFxf+BGDobJLnwkvgEwHIDBR6g==}
@@ -7041,6 +7450,9 @@ packages:
 
   '@stablelib/int@1.0.1':
     resolution: {integrity: sha512-byr69X/sDtDiIjIV6m4roLVWnNNlRGzsvxw+agj8CIEazqWGOQp2dTYgQhtyVXV9wpO6WyXRQUzLV/JRNumT2w==}
+
+  '@stablelib/int@2.0.1':
+    resolution: {integrity: sha512-Ht63fQp3wz/F8U4AlXEPb7hfJOIILs8Lq55jgtD7KueWtyjhVuzcsGLSTAWtZs3XJDZYdF1WcSKn+kBtbzupww==}
 
   '@stablelib/keyagreement@1.0.1':
     resolution: {integrity: sha512-VKL6xBwgJnI6l1jKrBAfn265cspaWBPAPEc62VBQrWHLqVgNRE09gQ/AnOEyKUWrrqfD+xSQ3u42gJjLDdMDQg==}
@@ -7054,6 +7466,9 @@ packages:
   '@stablelib/random@1.0.2':
     resolution: {integrity: sha512-rIsE83Xpb7clHPVRlBj8qNe5L8ISQOzjghYQm/dZ7VaM2KHYwMW5adjQjrzTZCchFnNCNhkwtnOBa9HTMJCI8w==}
 
+  '@stablelib/random@2.0.1':
+    resolution: {integrity: sha512-W6GAtXEEs7r+dSbuBsvoFmlyL3gLxle41tQkjKu17dDWtDdjhVUbtRfRCQcCUeczwkgjQxMPopgwYEvxXtHXGw==}
+
   '@stablelib/salsa20@1.0.2':
     resolution: {integrity: sha512-nfjKzw0KTKrrKBasEP+j7UP4I8Xudom8lVZIBCp0kQNARXq72IlSic0oabg2FC1NU68L4RdHrNJDd8bFwrphYA==}
 
@@ -7063,8 +7478,14 @@ packages:
   '@stablelib/sha512@1.0.1':
     resolution: {integrity: sha512-13gl/iawHV9zvDKciLo1fQ8Bgn2Pvf7OV6amaRVKiq3pjQ3UmEpXxWiAfV8tYjUpeZroBxtyrwtdooQT/i3hzw==}
 
+  '@stablelib/sha512@2.0.1':
+    resolution: {integrity: sha512-DUNe5cbnoH3sSIN+MG04RvTCLXtkbyy/SnQxiNO+GgF/KSXkkUSlF6mUVvCUdZBZ2X3NgogR+tAvaRSn8wxnLw==}
+
   '@stablelib/wipe@1.0.1':
     resolution: {integrity: sha512-WfqfX/eXGiAd3RJe4VU2snh/ZPwtSjLG4ynQ/vYzvghTh7dHFcI1wl+nrkWG6lGhukOxOsUHfv8dUXr58D0ayg==}
+
+  '@stablelib/wipe@2.0.1':
+    resolution: {integrity: sha512-1eU2K9EgOcV4qc9jcP6G72xxZxEm5PfeI5H55l08W95b4oRJaqhmlWRc4xZAm6IVSKhVNxMi66V67hCzzuMTAg==}
 
   '@stablelib/x25519@1.0.3':
     resolution: {integrity: sha512-KnTbKmUhPhHavzobclVJQG5kuivH+qDLpe84iRqX3CLrKp881cF160JvXJ+hjn1aMyCwYOKeIZefIH/P5cJoRw==}
@@ -7387,6 +7808,13 @@ packages:
   '@tanstack/virtual-core@3.5.0':
     resolution: {integrity: sha512-KnPRCkQTyqhanNC0K63GBG3wA8I+D1fQuVnAvcBF8f13akOKeQp1gSbu6f77zCxhEk727iV5oQnbHLYzHrECLg==}
 
+  '@tokenizer/inflate@0.4.1':
+    resolution: {integrity: sha512-2mAv+8pkG6GIZiF1kNg1jAjh27IDxEPKwdGul3snfztFerfPGI1LjDezZp3i7BElXompqEtPmoPx6c2wgtWsOA==}
+    engines: {node: '>=18'}
+
+  '@tokenizer/token@0.3.0':
+    resolution: {integrity: sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==}
+
   '@transmute/credentials-context@0.7.0-unstable.81':
     resolution: {integrity: sha512-TLXJkXwu+jscCVnAOuEmJYYbdaSaM6b2yk4R1g4T8gtTcTKts2G+KR5gE8A6W6QA5AuTZggwOWTxkISjErnYbw==}
 
@@ -7645,6 +8073,9 @@ packages:
   '@types/lodash@4.17.1':
     resolution: {integrity: sha512-X+2qazGS3jxLAIz5JDXDzglAF3KpijdhFxlf/V1+hEsOUc+HnWi81L/uv/EvGuV90WY+7mPGFCUDGfQC3Gj95Q==}
 
+  '@types/long@4.0.2':
+    resolution: {integrity: sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==}
+
   '@types/luxon@3.4.2':
     resolution: {integrity: sha512-TifLZlFudklWlMBfhubvgqTXRzLDI5pCbGa4P8a3wPyUQSW+1xQ5eDsreP9DWHX3tjq1ke96uYG/nwundroWcA==}
 
@@ -7659,6 +8090,9 @@ packages:
 
   '@types/mime@1.3.5':
     resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
+
+  '@types/minimatch@3.0.5':
+    resolution: {integrity: sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ==}
 
   '@types/minimist@1.2.4':
     resolution: {integrity: sha512-Kfe/D3hxHTusnPNRbycJE1N77WHDsdS4AjUYIzlDzhDrS47NrwuL3YW4VITxwR7KCVpzwgy4Rbj829KSSQmwXQ==}
@@ -7684,9 +8118,6 @@ packages:
   '@types/node@18.18.7':
     resolution: {integrity: sha512-bw+lEsxis6eqJYW8Ql6+yTqkE6RuFtsQPSe5JxXbqYRFQEER5aJA9a5UH9igqDWm3X4iLHIKOHlnAXLM4mi7uQ==}
 
-  '@types/node@18.19.33':
-    resolution: {integrity: sha512-NR9+KrpSajr2qBVp/Yt5TU/rp+b5Mayi3+OlMlcg2cVCfRmcG5PWZ7S4+MG9PZ5gWBoc9Pd0BKSRViuBCRPu0A==}
-
   '@types/node@18.19.56':
     resolution: {integrity: sha512-4EMJlWwwGnVPflJAtM14p9eVSa6BOv5b92mCsh5zcM1UagNtEtrbbtaE6WE1tw2TabavatnwqXjlIpcAEuJJNg==}
 
@@ -7695,6 +8126,9 @@ packages:
 
   '@types/node@20.12.11':
     resolution: {integrity: sha512-vDg9PZ/zi+Nqp6boSOT7plNuthRugEKixDv5sFTIpkE89MmNtEArAShI4mxuX2+UrLEe9pxC1vm2cjm9YlWbJw==}
+
+  '@types/node@22.7.5':
+    resolution: {integrity: sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==}
 
   '@types/node@22.7.6':
     resolution: {integrity: sha512-/d7Rnj0/ExXDMcioS78/kf1lMzYk4BZV8MZGTBKzTGZ6/406ukkbYlIsZmMPhcR5KlkunDHQLrtAVmSq7r+mSw==}
@@ -7883,6 +8317,9 @@ packages:
   '@veramo/did-provider-jwk@6.0.0':
     resolution: {integrity: sha512-aBQGpB6Rqi36hL0lAvrAQFhFGLKebWynYq1xf81KI4IPUfPXNeMoa5nzSCX7mlRDuORN0oh7deSUSsYdqmzjUg==}
 
+  '@veramo/did-provider-key@6.0.0':
+    resolution: {integrity: sha512-vEA1CpaGUWzGqTk0s5mhyaSgt1o09mjMWm/HAS0RR7Z+FTorlx7Kc7rhINBUmylzVKTsZQqeRlx0aSJhUxdUUw==}
+
   '@veramo/did-provider-pkh@6.0.0':
     resolution: {integrity: sha512-JskE9gYsokWidDcltgjIcETwi4VwMe0xjJmX+yO8cvkunSS5KxZ3o1+8Am31Dh/fzPGEYkyWGlDT63e11EglPw==}
 
@@ -7987,14 +8424,30 @@ packages:
   '@walletconnect/core@2.13.0':
     resolution: {integrity: sha512-blDuZxQenjeXcVJvHxPznTNl6c/2DO4VNrFnus+qHmO6OtT5lZRowdMtlCaCNb1q0OxzgrmBDcTOCbFcCpio/g==}
 
+  '@walletconnect/core@2.9.2':
+    resolution: {integrity: sha512-VARMPAx8sIgodeyngDHbealP3B621PQqjqKsByFUTOep8ZI1/R/20zU+cmq6j9RCrL+kLKZcrZqeVzs8Z7OlqQ==}
+
   '@walletconnect/environment@1.0.1':
     resolution: {integrity: sha512-T426LLZtHj8e8rYnKfzsw1aG6+M0BT1ZxayMdv/p8yM0MU+eJDISqNY3/bccxRr4LrF9csq02Rhqt08Ibl0VRg==}
 
   '@walletconnect/ethereum-provider@2.13.0':
     resolution: {integrity: sha512-dnpW8mmLpWl1AZUYGYZpaAfGw1HFkL0WSlhk5xekx3IJJKn4pLacX2QeIOo0iNkzNQxZfux1AK4Grl1DvtzZEA==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+
+  '@walletconnect/ethereum-provider@2.9.2':
+    resolution: {integrity: sha512-eO1dkhZffV1g7vpG19XUJTw09M/bwGUwwhy1mJ3AOPbOSbMPvwiCuRz2Kbtm1g9B0Jv15Dl+TvJ9vTgYF8zoZg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+    peerDependencies:
+      '@walletconnect/modal': '>=2'
+    peerDependenciesMeta:
+      '@walletconnect/modal':
+        optional: true
 
   '@walletconnect/events@1.0.1':
     resolution: {integrity: sha512-NPTqaoi0oPBVNuLv7qPaJazmGHs5JGyO8eEAk5VGKmJzDR7AHzD4k6ilox5kxk1iwiOnFopBOOMLs86Oa76HpQ==}
+
+  '@walletconnect/heartbeat@1.2.1':
+    resolution: {integrity: sha512-yVzws616xsDLJxuG/28FqtZ5rzrTA4gUjdEMTbWB5Y8V1XHRmqq4efAxCw5ie7WjbXFSUyBHaWlMR+2/CpQC5Q==}
 
   '@walletconnect/heartbeat@1.2.2':
     resolution: {integrity: sha512-uASiRmC5MwhuRuf05vq4AT48Pq8RMi876zV8rr8cV969uTOzWdB/k+Lj5yI2PBtB1bGQisGen7MM1GcZlQTBXw==}
@@ -8002,14 +8455,23 @@ packages:
   '@walletconnect/jsonrpc-http-connection@1.0.8':
     resolution: {integrity: sha512-+B7cRuaxijLeFDJUq5hAzNyef3e3tBDIxyaCNmFtjwnod5AGis3RToNqzFU33vpVcxFhofkpE7Cx+5MYejbMGw==}
 
+  '@walletconnect/jsonrpc-provider@1.0.13':
+    resolution: {integrity: sha512-K73EpThqHnSR26gOyNEL+acEex3P7VWZe6KE12ZwKzAt2H4e5gldZHbjsu2QR9cLeJ8AXuO7kEMOIcRv1QEc7g==}
+
   '@walletconnect/jsonrpc-provider@1.0.14':
     resolution: {integrity: sha512-rtsNY1XqHvWj0EtITNeuf8PHMvlCLiS3EjQL+WOkxEOA4KPxsohFnBDeyPYiNm4ZvkQdLnece36opYidmtbmow==}
+
+  '@walletconnect/jsonrpc-types@1.0.3':
+    resolution: {integrity: sha512-iIQ8hboBl3o5ufmJ8cuduGad0CQm3ZlsHtujv9Eu16xq89q+BG7Nh5VLxxUgmtpnrePgFkTwXirCTkwJH1v+Yw==}
 
   '@walletconnect/jsonrpc-types@1.0.4':
     resolution: {integrity: sha512-P6679fG/M+wuWg9TY8mh6xFSdYnFyFjwFelxyISxMDrlbXokorEVXYOxiqEbrU3x1BmBoCAJJ+vtEaEoMlpCBQ==}
 
   '@walletconnect/jsonrpc-utils@1.0.8':
     resolution: {integrity: sha512-vdeb03bD8VzJUL6ZtzRYsFMq1eZQcM3EAzT0a3st59dyLfJ0wq+tKMpmGH7HlB7waD858UWgfIcudbPFsbzVdw==}
+
+  '@walletconnect/jsonrpc-ws-connection@1.0.13':
+    resolution: {integrity: sha512-mfOM7uFH4lGtQxG+XklYuFBj6dwVvseTt5/ahOkkmpcAEgz2umuzu7fTR+h5EmjQBdrmYyEBOWADbeaFNxdySg==}
 
   '@walletconnect/jsonrpc-ws-connection@1.0.14':
     resolution: {integrity: sha512-Jsl6fC55AYcbkNVkwNM6Jo+ufsuCQRqViOQ8ZBPH9pRREHH9welbBiszuTLqEJiQcO/6XfFDl6bzCJIkrEi8XA==}
@@ -8025,14 +8487,25 @@ packages:
   '@walletconnect/logger@2.1.2':
     resolution: {integrity: sha512-aAb28I3S6pYXZHQm5ESB+V6rDqIYfsnHaQyzFbwUUBFY4H0OXx/YtTl8lvhUNhMMfb9UxbwEBS253TlXUYJWSw==}
 
+  '@walletconnect/modal-core@2.6.1':
+    resolution: {integrity: sha512-f2hYlJ5pwzGvjyaZ6BoGR5uiMgXzWXt6w6ktt1N8lmY6PiYp8whZgqx2hTxVWwVlsGnaIfh6UHp1hGnANx0eTQ==}
+
   '@walletconnect/modal-core@2.6.2':
     resolution: {integrity: sha512-cv8ibvdOJQv2B+nyxP9IIFdxvQznMz8OOr/oR/AaUZym4hjXNL/l1a2UlSQBXrVjo3xxbouMxLb3kBsHoYP2CA==}
+
+  '@walletconnect/modal-ui@2.6.1':
+    resolution: {integrity: sha512-RFUOwDAMijSK8B7W3+KoLKaa1l+KEUG0LCrtHqaB0H0cLnhEGdLR+kdTdygw+W8+yYZbkM5tXBm7MlFbcuyitA==}
 
   '@walletconnect/modal-ui@2.6.2':
     resolution: {integrity: sha512-rbdstM1HPGvr7jprQkyPggX7rP4XiCG85ZA+zWBEX0dVQg8PpAgRUqpeub4xQKDgY7pY/xLRXSiCVdWGqvG2HA==}
 
+  '@walletconnect/modal@2.6.1':
+    resolution: {integrity: sha512-G84tSzdPKAFk1zimgV7JzIUFT5olZUVtI3GcOk77OeLYjlMfnDT23RVRHm5EyCrjkptnvpD0wQScXePOFd2Xcw==}
+    deprecated: Please follow the migration guide on https://docs.reown.com/appkit/upgrade/wcm
+
   '@walletconnect/modal@2.6.2':
     resolution: {integrity: sha512-eFopgKi8AjKf/0U4SemvcYw9zlLpx9njVN8sf6DAkowC2Md0gPU/UNEbH1Wwj407pEKnEds98pKWib1NN1ACoA==}
+    deprecated: Please follow the migration guide on https://docs.reown.com/appkit/upgrade/wcm
 
   '@walletconnect/relay-api@1.0.10':
     resolution: {integrity: sha512-tqrdd4zU9VBNqUaXXQASaexklv6A54yEyQQEXYOCr+Jz8Ket0dmPBDyg19LVSNUN2cipAghQc45/KVmfFJ0cYw==}
@@ -8045,6 +8518,11 @@ packages:
 
   '@walletconnect/sign-client@2.13.0':
     resolution: {integrity: sha512-En7KSvNUlQFx20IsYGsFgkNJ2lpvDvRsSFOT5PTdGskwCkUfOpB33SQJ6nCrN19gyoKPNvWg80Cy6MJI0TjNYA==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+
+  '@walletconnect/sign-client@2.9.2':
+    resolution: {integrity: sha512-anRwnXKlR08lYllFMEarS01hp1gr6Q9XUgvacr749hoaC/AwGVlxYFdM8+MyYr3ozlA+2i599kjbK/mAebqdXg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/time@1.0.2':
     resolution: {integrity: sha512-uzdd9woDcJ1AaBZRhqy5rNC9laqWGErfc4dxA9a87mPdKOgWMD85mcFo9dIYIts/Jwocfwn07EC6EzclKubk/g==}
@@ -8052,11 +8530,22 @@ packages:
   '@walletconnect/types@2.13.0':
     resolution: {integrity: sha512-MWaVT0FkZwzYbD3tvk8F+2qpPlz1LUSWHuqbINUtMXnSzJtXN49Y99fR7FuBhNFtDalfuWsEK17GrNA+KnAsPQ==}
 
+  '@walletconnect/types@2.9.2':
+    resolution: {integrity: sha512-7Rdn30amnJEEal4hk83cdwHUuxI1SWQ+K7fFFHBMqkuHLGi3tpMY6kpyfDxnUScYEZXqgRps4Jo5qQgnRqVM7A==}
+
   '@walletconnect/universal-provider@2.13.0':
     resolution: {integrity: sha512-B5QvO8pnk5Bqn4aIt0OukGEQn2Auk9VbHfhQb9cGwgmSCd1GlprX/Qblu4gyT5+TjHMb1Gz5UssUaZWTWbDhBg==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
+
+  '@walletconnect/universal-provider@2.9.2':
+    resolution: {integrity: sha512-JmaolkO8D31UdRaQCHwlr8uIFUI5BYhBzqYFt54Mc6gbIa1tijGOmdyr6YhhFO70LPmS6gHIjljwOuEllmlrxw==}
+    deprecated: 'Reliability and performance improvements. See: https://github.com/WalletConnect/walletconnect-monorepo/releases'
 
   '@walletconnect/utils@2.13.0':
     resolution: {integrity: sha512-q1eDCsRHj5iLe7fF8RroGoPZpdo2CYMZzQSrw1iqL+2+GOeqapxxuJ1vaJkmDUkwgklfB22ufqG6KQnz78sD4w==}
+
+  '@walletconnect/utils@2.9.2':
+    resolution: {integrity: sha512-D44hwXET/8JhhIjqljY6qxSu7xXnlPrf63UN/Qfl98vDjWlYVcDl2+JIQRxD9GPastw0S8XZXdRq59XDXLuZBg==}
 
   '@walletconnect/window-getters@1.0.1':
     resolution: {integrity: sha512-vHp+HqzGxORPAN8gY03qnbTMnhqIwjeRJNOMOAzePRg4xVEEE2WvYsI9G2NMjOknA8hnuYbU3/hwLcKbjhc8+Q==}
@@ -8382,6 +8871,9 @@ packages:
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
 
+  any-signal@3.0.1:
+    resolution: {integrity: sha512-xgZgJtKEa9YmDqXodIgl7Fl1C8yNXr8w6gXjqK3LW4GcEiYT+6AQfJSE/8SPsEpLLmcvbv8YU+qet94UewHxqg==}
+
   anymatch@3.1.3:
     resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
     engines: {node: '>= 8'}
@@ -8514,6 +9006,9 @@ packages:
   available-typed-arrays@1.0.7:
     resolution: {integrity: sha512-wvUjBtSGN7+7SjNpq/9M2Tg350UZD3q62IFZLbRAR1bSMlCo1ZaeW+BJ+D090e4hIIZLBcTDWe4Mh4jvUDajzQ==}
     engines: {node: '>= 0.4'}
+
+  axios@0.21.4:
+    resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
 
   axios@1.1.3:
     resolution: {integrity: sha512-00tXVRwKx/FZr/IDVFt4C+f9FYairX517WoGCL6dpOntqLkZofjhu43F/Xl44UOpqa+9sLFDrG/XAnFsUYgkDA==}
@@ -8676,6 +9171,10 @@ packages:
     resolution: {integrity: sha512-WyftvZqye29YQ10ZnuiBeEj0lk8SN8xHU9hOznkLc85wS1cLTp6RpzlMrHxMPD9nH7S55gsBqMqgGyz93rqmkA==}
     engines: {node: '>=8.3.0'}
 
+  base64url-universal@2.0.0:
+    resolution: {integrity: sha512-6Hpg7EBf3t148C3+fMzjf+CHnADVDafWzlJUXAqqqbm4MKNXbsoPdOkWeRTjNlkYG7TpyjIpRO1Gk0SnsFD1rw==}
+    engines: {node: '>=14'}
+
   base64url@3.0.1:
     resolution: {integrity: sha512-ir1UPr3dkwexU7FdV8qBBbNDRUhMmIekYMFZfi+C/sLNnRESKPl23nB9b2pltqfOQNnGzsDdId90AEtG5tCx4A==}
     engines: {node: '>=6.0.0'}
@@ -8733,17 +9232,35 @@ packages:
   bindings@1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
 
+  bip174@2.1.1:
+    resolution: {integrity: sha512-mdFV5+/v0XyNYXjBS6CQPLo9ekCx4gtKZFnJm5PMto7Fs9hTTDpkkzOB7/FtluRI6JbUUAu+snTYfJRgHLZbZQ==}
+    engines: {node: '>=8.0.0'}
+
   bip66@1.1.5:
     resolution: {integrity: sha512-nemMHz95EmS38a26XbbdxIYj5csHd3RMP3H5bwQknX0WYHF01qhpufP42mLOwVICuH2JmhIhXiWs89MfUGL7Xw==}
 
+  bitcoinjs-lib@6.1.7:
+    resolution: {integrity: sha512-tlf/r2DGMbF7ky1MgUqXHzypYHakkEnm0SZP23CJKIqNY/5uNAnMbFhMJdhjrL/7anfb/U8+AlpdjPWjPnAalg==}
+    engines: {node: '>=8.0.0'}
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
+
+  bl@5.1.0:
+    resolution: {integrity: sha512-tv1ZJHLfTDnXE6tMHv73YgSJaWR2AFuPwMntBe7XL/GBFHnT0CLnsHMogfk5+GzCDC5ZWarSCYaIGATZt9dNsQ==}
 
   blake2b-wasm@2.4.0:
     resolution: {integrity: sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==}
 
   blakejs@1.2.1:
     resolution: {integrity: sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ==}
+
+  blob-to-it@1.0.4:
+    resolution: {integrity: sha512-iCmk0W4NdbrWgRRuxOriU8aM5ijeVLI61Zulsmg/lUHNr7pYjoj+U77opLefNagevtrrbMt3JQ5Qip7ar178kA==}
+
+  blockstore-core@3.0.0:
+    resolution: {integrity: sha512-5ZZB5nh6kErcjZ/CTK6lCwTIGlPdkTXbD8+2xLC4Fm0WGh7g2e2lW2bfURw7mvnPtSX1xV+sN4V2ndowSgIiHQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
@@ -8810,6 +9327,9 @@ packages:
     resolution: {integrity: sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==}
     hasBin: true
 
+  browser-readablestream-to-it@1.0.3:
+    resolution: {integrity: sha512-+12sHB+Br8HIh6VAMVEG5r3UXCyESIgDW7kzk3BjIXa43DVqVwL7GC5TW3jeh+72dtcH99pPVpw0X8i0jt+/kw==}
+
   browser-resolve@2.0.0:
     resolution: {integrity: sha512-7sWsQlYL2rGLy2IWm8WL8DCTJvYLc/qlOnsakDac87SOoCd16WLsaAMdCiAqsTNHIe+SXfaqyxyo6THoWqs8WQ==}
 
@@ -8859,6 +9379,9 @@ packages:
 
   bs58check@2.1.2:
     resolution: {integrity: sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==}
+
+  bs58check@3.0.1:
+    resolution: {integrity: sha512-hjuuJvoWEybo7Hn/0xOrczQKKEKD63WguEjlhLExYs2wUBcebDC1jDNK17eEAD2lYfw82d5ASC1d7K3SWszjaQ==}
 
   bser@2.1.1:
     resolution: {integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==}
@@ -9528,6 +10051,12 @@ packages:
       typescript:
         optional: true
 
+  cosmjs-types@0.10.1:
+    resolution: {integrity: sha512-CENXb4O5GN+VyB68HYXFT2SOhv126Z59631rZC56m8uMWa6/cSlFeai8BwZGT1NMepw0Ecf+U8XSOnBzZUWh9Q==}
+
+  cosmjs-types@0.7.2:
+    resolution: {integrity: sha512-vf2uLyktjr/XVAgEq0DjMxeAWh1yYREe7AMHDKd7EiHVqxBPCaBS+qEEQUkXbR9ndnckqr1sUG8BQhazh4X5lA==}
+
   crc-32@1.2.2:
     resolution: {integrity: sha512-ROmzCKrTnOwybPcJApAA6WBWij23HVfGVNKqqrZpuyZOHqK2CwHSvpGuyt/UNNvaIjEd8X5IFGp4Mh+Ie1IHJQ==}
     engines: {node: '>=0.8'}
@@ -9562,6 +10091,9 @@ packages:
     resolution: {integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==}
     engines: {node: '>=10.14', npm: '>=6', yarn: '>=1'}
     hasBin: true
+
+  cross-fetch@3.1.4:
+    resolution: {integrity: sha512-1eAtFWdIubi6T4XPy6ei9iUFoKpUkIF971QLN8lIvvvwueI65+Nw5haMNKUwfJxabqlIIDODJKGrQ66gxC0PbQ==}
 
   cross-fetch@3.1.8:
     resolution: {integrity: sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==}
@@ -9747,6 +10279,9 @@ packages:
   dag-jose-utils@3.0.0:
     resolution: {integrity: sha512-gu+XutOTy3kD8fDcA1SMjZ2U0mUOb/hxoRVZaMCizXN7Ssbc5dKOzeXQ4GquV4BdQzs3w5Y7irOpn2plFPIJfg==}
 
+  dag-jose@1.0.0:
+    resolution: {integrity: sha512-U0b/YsIPBp6YZNTFrVjwLZAlY3qGRxZTIEcM/CcQmrVrCWq9MWQq9pheXVSPLIhF4SNwzp2SikPva4/BIrJY+g==}
+
   dag-map@1.0.2:
     resolution: {integrity: sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw==}
 
@@ -9786,6 +10321,9 @@ packages:
 
   dataloader@2.2.2:
     resolution: {integrity: sha512-8YnDaaf7N3k/q5HnTJVuzSyLETjoZjVmHc4AeKAzOvKHEFQKcn64OKBfzHYtE9zGjctNM7V9I0MfnUVLpi7M5g==}
+
+  date-and-time@2.4.3:
+    resolution: {integrity: sha512-xkS/imTmsyEdpp9ie5oV5UWolg3XkYWNySbT2W4ESWr6v4V8YrsHbhpk9fIeQcr0NFTnYbQJLXlgU1zrLItysA==}
 
   date-fns@2.30.0:
     resolution: {integrity: sha512-fnULvOpxnC5/Vg3NCiWelDsLiUc9bRwAPs/+LfTLNvetFCtCTN+yQz15C/fs4AwX1R9K5GLtLfn8QW+dWisaAw==}
@@ -9830,6 +10368,15 @@ packages:
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
     peerDependencies:
       supports-color: '*'
@@ -10026,6 +10573,9 @@ packages:
   did-jwt@8.0.1:
     resolution: {integrity: sha512-J3AWsJhf8wJhKBjzCnFn2fgG403TF4uFnj+zpvQnUlMBu6+ySYj6nACFZ6FN+8Coj0kvbdXJermU6hs1Ihx3gA==}
 
+  did-jwt@8.0.18:
+    resolution: {integrity: sha512-yS3Y+aUKjYqRFrgR/RY77NuOOqS7SFfvfFH4THhWD6+hkxeUZcKQSsdNZ12QR1Vd48yP9exwae2wzbuOZn0NqQ==}
+
   did-jwt@8.0.4:
     resolution: {integrity: sha512-KPtG7H+8GgKGMiDqFvOdNy5BBN3hpA+8xV7VygEnpst5oPIqjvcH3rTtnPF55a8bOxIzE2PudKGIXIQhekv7WA==}
 
@@ -10063,6 +10613,9 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dns-over-http-resolver@1.2.3:
+    resolution: {integrity: sha512-miDiVSI6KSNbi4SVifzO/reD8rMnxgrlnkrlkugOLQpWQTe2qMdHsZp5DmfKjxNE+/T3VAAYLQUZMv9SMr6+AA==}
 
   dns-packet@5.6.1:
     resolution: {integrity: sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==}
@@ -10199,6 +10752,10 @@ packages:
     engines: {node: '>=0.10.0'}
     hasBin: true
 
+  electron-fetch@1.9.1:
+    resolution: {integrity: sha512-M9qw6oUILGVrcENMSRRefE1MbHPIz0h79EKIeJWK9v563aT9Qkh8aEHPO1H5vi970wPirNY+jO9OpFoLiMsMGA==}
+    engines: {node: '>=6'}
+
   electron-to-chromium@1.4.540:
     resolution: {integrity: sha512-aoCqgU6r9+o9/S7wkcSbmPRFi7OWZWiXS9rtjEd+Ouyu/Xyw5RSq2XN8s5Qp8IaFOLiRrhQCphCIjAxgG3eCAg==}
 
@@ -10213,6 +10770,9 @@ packages:
 
   elliptic@6.5.5:
     resolution: {integrity: sha512-7EjbcmUm17NQFu4Pmgmq2olYMj8nwMnpcddByChSUjArp8F5DQWcIcpriwO4ZToLNAJig0yiyjswfyGNje/ixw==}
+
+  elliptic@6.6.1:
+    resolution: {integrity: sha512-RaddvvMatK2LJHqFJ+YA4WysVN5Ita9E35botqIYspQ4TkRAlCicdzKOjlyv/1Za5RyTNn7di//eEV0uTAfe3g==}
 
   emittery@0.13.1:
     resolution: {integrity: sha512-DeWwawk6r5yR9jFgnDKYt4sLS0LmHJJi3ZOnb5/JdbYwj3nW+FxQnHIjhBKz8YLC7oRNPVM9NQ47I3CVx34eqQ==}
@@ -10529,6 +11089,10 @@ packages:
     resolution: {integrity: sha512-mxTAE6wqJQAbp5QAe/+o+rXOID7Nw91OZXvgpjDa1r4fAbq2Nu314oEZSbjoRLacuCzs7kUC3clEvkCQowffGg==}
     engines: {node: '>=14.0.0'}
 
+  ethers@6.16.0:
+    resolution: {integrity: sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==}
+    engines: {node: '>=14.0.0'}
+
   ethers@6.8.0:
     resolution: {integrity: sha512-zrFbmQRlraM+cU5mE4CZTLBurZTs2gdp2ld0nG/f3ecBK+x6lZ69KSxBqZ4NjclxwfTxl5LeNufcBbMsTdY53Q==}
     engines: {node: '>=14.0.0'}
@@ -10652,8 +11216,8 @@ packages:
     resolution: {integrity: sha512-aRKrheMMQBcNDg2SBjW5kcSN5G58bdIpsxeSQ65Bx18DFLXjPv5UaU9kzIWRAcxaPtgictn9ut9IJQVZKChNxQ==}
     hasBin: true
 
-  exponential-backoff@3.1.1:
-    resolution: {integrity: sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==}
+  exponential-backoff@3.1.3:
+    resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
 
   express@4.19.2:
     resolution: {integrity: sha512-5T6nhjsT+EOMzuck8JjBHARTHfMht0POzlA60WV2pMD3gyXw2LZnZ+ueGdNxG+0calOJcWKbpFcuzLZ91YWq9Q==}
@@ -10689,6 +11253,9 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-fifo@1.3.2:
+    resolution: {integrity: sha512-/d9sfos4yxzpwkDkuN7k2SqFKtYNmCTzgfEpz82x34IM9/zc8KGxQoXg1liNC/izpRM/MBdt44Nmx41ZWqk+FQ==}
 
   fast-glob@3.2.7:
     resolution: {integrity: sha512-rYGMRwip6lUMvYD3BTScMwT1HtAs2d71SMv66Vrxs0IekGZEjhM0pcMfjQPnknBt2zeCwQMEupiN02ZP4DiT1Q==}
@@ -10802,6 +11369,14 @@ packages:
 
   file-saver@2.0.5:
     resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
+
+  file-type@16.5.4:
+    resolution: {integrity: sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw==}
+    engines: {node: '>=10'}
+
+  file-type@21.1.1:
+    resolution: {integrity: sha512-ifJXo8zUqbQ/bLbl9sFoqHNTNWbnPY1COImFfM6CCy7z+E+jC1eY9YfOKkx0fckIg+VljAy2/87T61fp0+eEkg==}
+    engines: {node: '>=20'}
 
   file-uri-to-path@1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
@@ -11065,6 +11640,9 @@ packages:
     resolution: {integrity: sha512-Ozxyi23/1Ar51wjUT2RDklK+3HxqDr8TLBNK8rBBFQ7T85iIGnXnVusauj06QyqCXRFZig8LZC+TUddWbndlpQ==}
     engines: {node: '>=14'}
 
+  generate-password@1.7.1:
+    resolution: {integrity: sha512-9bVYY+16m7W7GczRBDqXE+VVuCX+bWNrfYKC/2p2JkZukFb2sKxT6E3zZ3mJGz7GMe5iRK0A/WawSL3jQfJuNQ==}
+
   genson-js@0.0.5:
     resolution: {integrity: sha512-1i1y9MIGzTRkn4TusWQwLWLu8IJGHgSE+fbQRt1fy68ZKEq2GjDZI/7NUSZFOfTbHz8bgjP4iCIOcdYrgEsMBA==}
 
@@ -11092,6 +11670,9 @@ packages:
   get-intrinsic@1.2.6:
     resolution: {integrity: sha512-qxsEs+9A+u85HhllWJJFicJfPDhRmjzoYdl64aMWW9yRIJmSyxdn8IEkuIM530/7T+lv0TIHd8L6Q/ra0tEoeA==}
     engines: {node: '>= 0.4'}
+
+  get-iterator@1.0.2:
+    resolution: {integrity: sha512-v+dm9bNVfOYsY1OrhaCrmyOcYoSeVvbt+hHZ0Au+T+p1y+0Uyj9aMaGIeUTT6xdpRbWzDeYKvfOslPhggQMcsg==}
 
   get-nonce@1.0.1:
     resolution: {integrity: sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==}
@@ -11266,6 +11847,9 @@ packages:
   h3@1.11.1:
     resolution: {integrity: sha512-AbaH6IDnZN6nmbnJOH72y3c5Wwh9P97soSVdGSBbcDACRdkC0FEWf25pzx4f/NuOCK6quHmW18yF2Wx+G4Zi1A==}
 
+  hamt-sharding@3.0.6:
+    resolution: {integrity: sha512-nZeamxfymIWLpVcAN0CRrb7uVq3hCOGj9IcL6NMA6VVCVWqj+h9Jo/SmaWuS92AEDf1thmHsM5D5c70hM3j2Tg==}
+
   handle-thing@2.0.1:
     resolution: {integrity: sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==}
 
@@ -11329,6 +11913,9 @@ packages:
   hash-base@3.1.0:
     resolution: {integrity: sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==}
     engines: {node: '>=4'}
+
+  hash-wasm@4.12.0:
+    resolution: {integrity: sha512-+/2B2rYLb48I/evdOIhP+K/DD2ca2fgBjp6O+GBEnCDk2e4rpeXIK8GvIyRPjTezgmWn9gmKwkQjjx6BtqDHVQ==}
 
   hash.js@1.1.7:
     resolution: {integrity: sha512-taOaskGt4z4SOANNseOviYDvjEJinIkRgmp7LbKP2YTTmVxWBl87s/uzK9r+44BclBSp2X7K1hqeNfz9JbBeXA==}
@@ -11605,6 +12192,9 @@ packages:
     engines: {node: '>=16.x'}
     hasBin: true
 
+  immediate@3.0.6:
+    resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+
   immer@10.1.1:
     resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
 
@@ -11684,6 +12274,20 @@ packages:
     resolution: {integrity: sha512-ufS5Qq9RZN+Bu899eA9QCAYThY+gGW7oRkmb0vC93Vlyu/CFGcH0OYPEjVkDXA5FEbTt1+VWzdoOD3Ny9N+8tg==}
     hasBin: true
 
+  interface-blockstore@4.0.1:
+    resolution: {integrity: sha512-ROWKGJls7vLeFaQtI3hZVCJOkUoZ05xAi2t2qysM4d7dwVKrfm5jUOqWh8JgLL7Iup3XqJ0mKXXZuwJ3s03RSw==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  interface-datastore@6.1.1:
+    resolution: {integrity: sha512-AmCS+9CT34pp2u0QQVXjKztkuq3y5T+BIciuiHDDtDZucZD8VudosnSdUyXJV6IsRkN5jc4RFDhCk1O6Q3Gxjg==}
+
+  interface-store@2.0.2:
+    resolution: {integrity: sha512-rScRlhDcz6k199EkHqT8NpM87ebN89ICOzILoBHgaG36/WX50N32BnU/kpZgCGPLhARRAWUUX5/cyaIjt7Kipg==}
+
+  interface-store@3.0.4:
+    resolution: {integrity: sha512-OjHUuGXbH4eXSBx1TF1tTySvjLldPLzRSYYXJwrEQI+XfH5JWYZofr0gVMV4F8XTwC+4V7jomDYkvGRmDSRKqQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   internal-ip@4.3.0:
     resolution: {integrity: sha512-S1zBo1D6zcsyuC6PMmY5+55YMILQ9av8lotMx447Bq6SAgo/sDK6y6uUKmuYhW7eacnIhFfsPmCNYdDzsnnDCg==}
     engines: {node: '>=6'}
@@ -11717,6 +12321,10 @@ packages:
     resolution: {integrity: sha512-58yWmlHpp7VYfcdTwMTvwMmqx/Elfxjd9RXTDyMsbL7lLWmhMylLEqiYVLKuLzOZqVgiWXD9MfR62Vv89VRxkw==}
     engines: {node: '>=4'}
 
+  ip-regex@4.3.0:
+    resolution: {integrity: sha512-B9ZWJxHHOHUhUjCPrMpLD4xEq35bUTClHM1S6CBU5ixQnkZmwipwgc96vAd7AAGM9TGHvJR+Uss+/Ak6UphK+Q==}
+    engines: {node: '>=8'}
+
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
@@ -11725,8 +12333,37 @@ packages:
     resolution: {integrity: sha512-Ag3wB2o37wslZS19hZqorUnrnzSkpOVy+IiiDEiTqNubEYpYuHWIf6K4psgN2ZWKExS4xhVCrRVfb/wfW8fWJA==}
     engines: {node: '>= 10'}
 
+  ipfs-core-types@0.10.3:
+    resolution: {integrity: sha512-GNid2lRBjR5qgScCglgk7w9Hk3TZAwPHQXxOLQx72wgyc0jF2U5NXRoKW0GRvX8NPbHmsrFszForIqxd23I1Gw==}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-core-utils@0.14.3:
+    resolution: {integrity: sha512-aBkewVhgAj3NWXPwu6imj0wADGiGVZmJzqKzODOJsibDjkx6FGdMv8kvvqtLnK8LS/dvSk9yk32IDtuDyYoV7Q==}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-http-client@56.0.0:
+    resolution: {integrity: sha512-JF3on9c0hB9XHk/UCxbyC6rSpERuj8F/0QcN/HImZoHNUKZ0/T8DpgVopocKdmGi1gr3Izlop7poaXomSt8Nug==}
+    engines: {node: '>=15.0.0', npm: '>=3.0.0'}
+    deprecated: js-IPFS has been deprecated in favour of Helia - please see https://github.com/ipfs/js-ipfs/issues/4336 for details
+
+  ipfs-unixfs-importer@12.0.1:
+    resolution: {integrity: sha512-//VPZOqbONtc1HNtb+sBrw+nIGijHEloSm1O3LVR5orSlhHQ8X7+OCkeqceFBhu40tPMe/TwgAPrkvh+fXL+bA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   ipfs-unixfs@11.1.2:
     resolution: {integrity: sha512-HVjrACOhU8RgMskcrfydk+FDAE9pFKr8tneKLaVYQ2f81HUKXoiSdgsAJY/jt7Ieyj4tE12TZGduIeWtNpScOw==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  ipfs-unixfs@6.0.9:
+    resolution: {integrity: sha512-0DQ7p0/9dRB6XCb0mVCTli33GzIzSVx5udpJuVM47tGcD+W+Bl4LsnoLswd3ggNnNEakMv1FdoFITiEnchXDqQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  ipfs-unixfs@9.0.1:
+    resolution: {integrity: sha512-jh2CbXyxID+v3jLml9CqMwjdSS9ZRnsGfQGGPOfem0/hT/L48xUeTPvh7qLFWkZcIMhZtG+fnS1teei8x5uGBg==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  ipfs-utils@9.0.14:
+    resolution: {integrity: sha512-zIaiEGX18QATxgaS0/EOQNoo33W0islREABAcxXE8n7y2MGAlB+hdsxXn4J0hGZge8IqVQhW8sWIb+oJz2yEvg==}
     engines: {node: '>=16.0.0', npm: '>=7.0.0'}
 
   iron-webcrypto@1.2.1:
@@ -11810,6 +12447,9 @@ packages:
     engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
     hasBin: true
 
+  is-electron@2.2.2:
+    resolution: {integrity: sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==}
+
   is-extendable@0.1.1:
     resolution: {integrity: sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==}
     engines: {node: '>=0.10.0'}
@@ -11881,6 +12521,10 @@ packages:
   is-invalid-path@0.1.0:
     resolution: {integrity: sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==}
     engines: {node: '>=0.10.0'}
+
+  is-ip@3.1.0:
+    resolution: {integrity: sha512-35vd5necO7IitFPjd/YBeqwWnyDWbuLH9ZXQdMfDA8TEo7pv5X8yfrvVO3xbJbLUlERCMvf6X0hTUamQxCYJ9Q==}
+    engines: {node: '>=8'}
 
   is-map@2.0.3:
     resolution: {integrity: sha512-1Qed0/Hr2m+YqxnM09CjA2d/i6YZNfF6R2oRAOj36eUdS6qIV/huPJNSEpKbupewFs+ZsJlxsjjPbc0/afW6Lw==}
@@ -12067,6 +12711,10 @@ packages:
   isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  iso-url@1.2.1:
+    resolution: {integrity: sha512-9JPDgCN4B7QPkLtYAAOrEuAWvP9rWvR5offAr0/SeF046wIkglqH3VXgYYP6NcsKslH80UIVgmPqNe3j7tG2ng==}
+    engines: {node: '>=12'}
+
   isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
@@ -12080,6 +12728,11 @@ packages:
 
   isomorphic-webcrypto@2.3.8:
     resolution: {integrity: sha512-XddQSI0WYlSCjxtm1AI8kWQOulf7hAN3k3DclF1sxDJZqOe0pcsOt675zvWW91cZH9hYs3nlA3Ev8QK5i80SxQ==}
+
+  isomorphic-ws@4.0.1:
+    resolution: {integrity: sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==}
+    peerDependencies:
+      ws: '*'
 
   isows@1.0.3:
     resolution: {integrity: sha512-2cKei4vlmg2cxEjm3wVSqn8pcoRF/LX/wpifuuNquFO4SQmPwarClT+SUCA2lt+l581tTeZIPIZuIDo2jWN1fg==}
@@ -12114,8 +12767,54 @@ packages:
     resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
     engines: {node: '>=8'}
 
+  it-all@1.0.6:
+    resolution: {integrity: sha512-3cmCc6Heqe3uWi3CVM/k51fa/XbMFpQVzFoDsV0IZNHSQDyAXl3c4MjHkFX5kF3922OGj7Myv1nSEUgRtcuM1A==}
+
+  it-all@2.0.1:
+    resolution: {integrity: sha512-9UuJcCRZsboz+HBQTNOau80Dw+ryGaHYFP/cPYzFBJBFcfDathMYnhHk4t52en9+fcyDGPTdLB+lFc1wzQIroA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-batch@2.0.1:
+    resolution: {integrity: sha512-2gWFuPzamh9Dh3pW+OKjc7UwJ41W4Eu2AinVAfXDMfrC5gXfm3b1TF+1UzsygBUgKBugnxnGP+/fFRyn+9y1mQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-drain@2.0.1:
+    resolution: {integrity: sha512-ESuHV6MLUNxuSy0vGZpKhSRjW0ixczN1FhbVy7eGJHjX6U2qiiXTyMvDc0z/w+nifOOwPyI5DT9Rc3o9IaGqEQ==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-filter@2.0.2:
+    resolution: {integrity: sha512-gocw1F3siqupegsOzZ78rAc9C+sYlQbI2af/TmzgdrR613MyEJHbvfwBf12XRekGG907kqXSOGKPlxzJa6XV1Q==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
   it-first@1.0.7:
     resolution: {integrity: sha512-nvJKZoBpZD/6Rtde6FXqwDqDZGF1sCADmr2Zoc0hZsIvnE449gRFnGctxDf09Bzc/FWnHXAdaHVIetY6lrE0/g==}
+
+  it-first@2.0.1:
+    resolution: {integrity: sha512-noC1oEQcWZZMUwq7VWxHNLML43dM+5bviZpfmkxkXlvBe60z7AFRqpZSga9uQBo792jKv9otnn1IjA4zwgNARw==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-glob@1.0.2:
+    resolution: {integrity: sha512-Ch2Dzhw4URfB9L/0ZHyY+uqOnKvBNeS/SMcRiPmJfpHiM0TsUZn+GkpcZxAoF3dJVdPm/PuIk3A4wlV7SUo23Q==}
+
+  it-last@1.0.6:
+    resolution: {integrity: sha512-aFGeibeiX/lM4bX3JY0OkVCFkAw8+n9lkukkLNivbJRvNz8lI3YXv5xcqhFUV2lDJiraEK3OXRDbGuevnnR67Q==}
+
+  it-map@1.0.6:
+    resolution: {integrity: sha512-XT4/RM6UHIFG9IobGlQPFQUrlEKkU4eBUFG3qhWhfAdh1JfF2x11ShCrKCdmZ0OiZppPfoLuzcfA4cey6q3UAQ==}
+
+  it-parallel-batch@2.0.1:
+    resolution: {integrity: sha512-tXh567/JfDGJ90Zi//H9HkL7kY27ARp0jf2vu2jUI6PUVBWfsoT+gC4eT41/b4+wkJXSGgT8ZHnivAOlMfcNjA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-peekable@1.0.3:
+    resolution: {integrity: sha512-5+8zemFS+wSfIkSZyf0Zh5kNN+iGyccN02914BY4w/Dj+uoFEoPSvj5vaWn8pNZJNSxzjW0zHRxC3LUb2KWJTQ==}
+
+  it-take@2.0.1:
+    resolution: {integrity: sha512-DL7kpZNjuoeSTnB9dMAJ0Z3m2T29LRRAU+HIgkiQM+1jH3m8l9e/1xpWs8JHTlbKivbqSFrQMTc8KVcaQNmsaA==}
+    engines: {node: '>=16.0.0', npm: '>=7.0.0'}
+
+  it-to-stream@1.0.0:
+    resolution: {integrity: sha512-pLULMZMAB/+vbdvbZtebC0nWBTbG581lk6w8P7DfIIIKUfa8FbY7Oi0FxZcFPbxvISs7A9E+cMpLDBc1XhpAOA==}
 
   jackspeak@2.3.6:
     resolution: {integrity: sha512-N3yCS/NegsOBokc8GAdM8UcmfsKiSS8cipheD/nivzr700H+nsMOxJjQnvwOcRYVuFkdH0wGUvW2WbXGmrZGbQ==}
@@ -12401,12 +13100,20 @@ packages:
     resolution: {integrity: sha512-jclmnPRrm5SEpaIV6IiSTJxplRAqIWHduQLsUfrYpZM41Ng48m1RN2/aUyHze/ynfO0D2UhlJBt8SdObsH5GBw==}
     engines: {node: '>=10'}
 
+  jsonld-signatures@11.5.0:
+    resolution: {integrity: sha512-Kdto+e8uvY/5u3HYkmAbpy52bplWX9uqS8fmqdCv6oxnCFwCTM0hMt6r4rWqlhw5/aHoCHJIRxwYb4QKGC69Jw==}
+    engines: {node: '>=18'}
+
   jsonld@5.2.0:
     resolution: {integrity: sha512-JymgT6Xzk5CHEmHuEyvoTNviEPxv6ihLWSPu1gFdtjSAyM6cFqNrv02yS/SIur3BBIkCf0HjizRc24d8/FfQKw==}
     engines: {node: '>=12'}
 
   jsonld@8.3.1:
     resolution: {integrity: sha512-tYfKpWL56meSJCHS91Ph0+EUThHZOZ8bKuboME4998SF+Kkukp2PhCPdRCvA7tsGUKr9FvSoyIRqJPuImBcBuA==}
+    engines: {node: '>=14'}
+
+  jsonld@8.3.3:
+    resolution: {integrity: sha512-9YcilrF+dLfg9NTEof/mJLMtbdX1RJ8dbWtJgE00cMOIohb1lIyJl710vFiTaiHTl6ZYODJuBd32xFvUhmv3kg==}
     engines: {node: '>=14'}
 
   jsonld@https://codeload.github.com/digitalcredentials/jsonld.js/tar.gz/14357f7a1181ae769ecc50fee9303468f17665ff:
@@ -12430,6 +13137,9 @@ packages:
   jsonwebtoken@9.0.2:
     resolution: {integrity: sha512-PRp66vJ865SSqOlgqS8hujT5U4AOgMfhrwYIuIhfKaoSCZcirrmASQr8CX7cUg+RMih+hgznrjp99o+W4pJLHQ==}
     engines: {node: '>=12', npm: '>=6'}
+
+  jszip@3.10.1:
+    resolution: {integrity: sha512-xXDvecyTpGLrqFrvkrUSoxxfJI5AH7U8zxxtVclpsUtMCq4JQ290LY8AW5c7Ggnr/Y/oK+bQMbqK2qmtk3pN4g==}
 
   jwa@1.4.1:
     resolution: {integrity: sha512-qiLX/xhEEFKUAJ6FiBMbes3w9ATzyk5W7Hvzpa/SLYdxNtng+gcurvrI7TbACjIXlsJyr05/S1oUhZrc63evQA==}
@@ -12533,6 +13243,15 @@ packages:
     resolution: {integrity: sha512-0OO4y2iOHix2W6ujICbKIaEQXvFQHue65vUG3pb5EUomzPI90z9hsA1VsO/dbIIpC53J8gxM9Q4Oho0jrCM/yA==}
     engines: {node: '>= 0.8.0'}
 
+  libsodium-wrappers@0.7.15:
+    resolution: {integrity: sha512-E4anqJQwcfiC6+Yrl01C1m8p99wEhLmJSs0VQqST66SbQXXBoaJY0pF4BNjRYa/sOQAxx6lXAaAFIlx+15tXJQ==}
+
+  libsodium@0.7.15:
+    resolution: {integrity: sha512-sZwRknt/tUpE2AwzHq3jEyUU5uvIZHtSssktXq7owd++3CSgn8RGrv6UZJJBpP7+iBghBqe7Z06/2M31rI2NKw==}
+
+  lie@3.3.0:
+    resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
+
   lighthouse-logger@1.4.2:
     resolution: {integrity: sha512-gPWxznF6TKmUHrOQjlVo2UbaL2EJ71mb2CCeRs/2qBpi4L/g4LUVc9+3lKQ6DTUZwJswfM7ainGrLO1+fOqa2g==}
 
@@ -12629,6 +13348,17 @@ packages:
   lit-html@2.8.0:
     resolution: {integrity: sha512-o9t+MQM3P4y7M7yNzqAyjp7z+mQGa4NS4CxiyLqFPyFWyc4O+nodLrkrxSaCTrla6M5YOLaT3RpbbqjszB5g3Q==}
 
+  lit-siwe@1.1.8:
+    resolution: {integrity: sha512-gXI8GG0GAClw6G7T9p4p6Kn9ywDo8j2d90ShaYArJdsqqO9gwXfzxF84SMeY+bpsNqqQ3FahrhEwTCHd6w7wNw==}
+    peerDependencies:
+      '@ethersproject/contracts': ^5.2.0
+      '@ethersproject/hash': ^5.4.0
+      '@ethersproject/providers': ^5.2.0
+      '@ethersproject/wallet': ^5.2.0
+
+  lit@2.7.6:
+    resolution: {integrity: sha512-1amFHA7t4VaaDe+vdQejSVBklwtH9svGoG6/dZi9JhxtJBBlqY5D1RV7iLUYY0trCqQc4NfhYYZilZiVHt7Hxg==}
+
   lit@2.8.0:
     resolution: {integrity: sha512-4Sc3OFX9QHOJaHbmTMk28SYgVxLN3ePDjg7hofEft2zWlehFL3LiAuapWc4U/kYwMYJSh2hTCPZ6/LIC7ii0MA==}
 
@@ -12689,6 +13419,7 @@ packages:
 
   lodash.get@4.4.2:
     resolution: {integrity: sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==}
+    deprecated: This package is deprecated. Use the optional chaining (?.) operator instead.
 
   lodash.includes@4.3.0:
     resolution: {integrity: sha512-W3Bx6mdkRTGtlJISOvVD/lbqjTlPPUDTMnlXZFnVwi9NKJ6tiAk6LVdlhZMm17VZisqhKcgzpO5Wz91PCt5b0w==}
@@ -12701,6 +13432,7 @@ packages:
 
   lodash.isequal@4.5.0:
     resolution: {integrity: sha512-pDo3lu8Jhfjqls6GkMgpahsF9kCyayhgykjyLMNFTKWrpVdAQtYyB4muAMWozBB4ig/dtWAmsMxLEI8wuz+DYQ==}
+    deprecated: This package is deprecated. Use require('node:util').isDeepStrictEqual instead.
 
   lodash.isinteger@4.0.4:
     resolution: {integrity: sha512-DBwtEWN2caHQ9/imiNeEA5ys1JoRtRfY3d7V9wkqtbycnAmTvRRmbHKDV4a0EYc678/dia0jrte4tjYwVBaZUA==}
@@ -12734,6 +13466,7 @@ packages:
 
   lodash.omit@4.5.0:
     resolution: {integrity: sha512-XeqSp49hNGmlkj2EJlfrQFIzQ6lXdNro9sddtQzcJY8QaoC2GO0DT7xaIokHeyM+mIT0mPMlPvkYzg2xCuHdZg==}
+    deprecated: This package is deprecated. Use destructuring assignment syntax instead.
 
   lodash.once@4.1.1:
     resolution: {integrity: sha512-Sb487aTOCr9drQVL8pIxOzVhafOjZN9UU54hiN8PU3uAiSV7lx1yYNpbNmex2PK6dSJoNTSJUUswT651yww3Mg==}
@@ -12781,6 +13514,12 @@ packages:
 
   logplease@1.2.15:
     resolution: {integrity: sha512-jLlHnlsPSJjpwUfcNyUxXCl33AYg2cHhIf9QhGL2T4iPT0XPB+xP1LRKFPgIg1M/sg9kAJvy94w9CzBNrfnstA==}
+
+  long@4.0.0:
+    resolution: {integrity: sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==}
+
+  long@5.3.2:
+    resolution: {integrity: sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==}
 
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
@@ -13406,6 +14145,14 @@ packages:
   msrcrypto@1.5.8:
     resolution: {integrity: sha512-ujZ0TRuozHKKm6eGbKHfXef7f+esIhEckmThVnz7RNyiOJd7a6MXj2JGBoL9cnPDW+JMG16MoTUh5X+XXjI66Q==}
 
+  multiaddr-to-uri@8.0.0:
+    resolution: {integrity: sha512-dq4p/vsOOUdVEd1J1gl+R2GFrXJQH8yjLtz4hodqdVbieg39LvBOdMQRdQnfbg5LSM/q1BYNVf5CBbwZFFqBgA==}
+    deprecated: This module is deprecated, please upgrade to @multiformats/multiaddr-to-uri
+
+  multiaddr@10.0.1:
+    resolution: {integrity: sha512-G5upNcGzEGuTHkzxezPrrD6CaIHR9uo+7MwqhNVcXTs33IInon4y7nMiGxl2CY5hG7chvYQUQhz5V52/Qe3cbg==}
+    deprecated: This module is deprecated, please upgrade to @multiformats/multiaddr
+
   multibase@4.0.6:
     resolution: {integrity: sha512-x23pDe5+svdLz/k5JPGCVdfn7Q5mZVMBETiC+ORfO+sor9Sgs0smJzAjfTbM5tckeCqnaUuMYoz+k3RXMmJClQ==}
     engines: {node: '>=12.0.0', npm: '>=6.0.0'}
@@ -13426,8 +14173,15 @@ packages:
   multiformats@13.1.0:
     resolution: {integrity: sha512-HzdtdBwxsIkzpeXzhQ5mAhhuxcHbjEHH+JQoxt7hG/2HGFjjwyolLo7hbaexcnhoEuV4e0TNJ8kkpMjiEYY4VQ==}
 
+  multiformats@13.4.2:
+    resolution: {integrity: sha512-eh6eHCrRi1+POZ3dA+Dq1C6jhP1GNtr9CRINMb67OKzqW9I5DUuZM/3jLPlzhgpGeiNUlEGEbkCYChXMCc/8DQ==}
+
   multiformats@9.9.0:
     resolution: {integrity: sha512-HoMUjhH9T8DDBNT+6xzkrd9ga/XiBI4xLr58LJACwK6G3HTOPeMz4nB4KJs33L2BelrIJa7P0VuNaVF3hMYfjg==}
+
+  murmurhash3js-revisited@3.0.0:
+    resolution: {integrity: sha512-/sF3ee6zvScXMb1XFJ8gDsSnY+X8PbOyjIuBhtgis10W2Jx4ZjIhikUCIF9c4gpJxVnQIsPAFrSwTCuAjicP6g==}
+    engines: {node: '>=8.0.0'}
 
   mute-stream@0.0.8:
     resolution: {integrity: sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==}
@@ -13452,6 +14206,11 @@ packages:
 
   napi-build-utils@1.0.2:
     resolution: {integrity: sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==}
+
+  native-fetch@3.0.0:
+    resolution: {integrity: sha512-G3Z7vx0IFb/FQ4JxvtqGABsOTIqRWvgQz6e+erkB+JJD6LrszQtMozEHI4EkmgZQvnGHrpLVzUWk7t4sJCIkVw==}
+    peerDependencies:
+      node-fetch: '*'
 
   natural-compare@1.4.0:
     resolution: {integrity: sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==}
@@ -13488,6 +14247,7 @@ packages:
   next@14.2.3:
     resolution: {integrity: sha512-dowFkFTR8v79NPJO4QsBUtxv0g9BrS/phluVpMAt2ku7H+cbcBJlopXjkWlwxrk/xGqMemr7JkGPGemPrLLX7A==}
     engines: {node: '>=18.17.0'}
+    deprecated: This version has a security vulnerability. Please upgrade to a patched version. See https://nextjs.org/blog/security-update-2025-12-11 for more details.
     hasBin: true
     peerDependencies:
       '@opentelemetry/api': ^1.1.0
@@ -13540,6 +14300,7 @@ packages:
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
+    deprecated: Use your platform's native DOMException instead
 
   node-emoji@2.1.3:
     resolution: {integrity: sha512-E2WEOVsgs7O16zsURJ/eH8BqhF029wGpEOnv7Urwdo2wmQanOACwJQh0devF9D9RhoZru0+9JXIS0dBXIAz+lA==}
@@ -13547,6 +14308,10 @@ packages:
 
   node-fetch-native@1.6.4:
     resolution: {integrity: sha512-IhOigYzAKHd244OC0JIMIUrjzctirCmPkaIfhDeGcEETWof5zKYUW7e7MYvChGWh/4CJeXEgsRyGzuF334rOOQ==}
+
+  node-fetch@2.6.1:
+    resolution: {integrity: sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==}
+    engines: {node: 4.x || >=6.0.0}
 
   node-fetch@2.7.0:
     resolution: {integrity: sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==}
@@ -13571,10 +14336,6 @@ packages:
 
   node-gyp-build@4.6.0:
     resolution: {integrity: sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==}
-    hasBin: true
-
-  node-gyp-build@4.6.1:
-    resolution: {integrity: sha512-24vnklJmyRS8ViBNI8KbtK/r/DmXQMRiOMXTNz2nrTnAYUwjmEEbnnpB/+kt+yWRv73bPsSPRFddrcIbAxSiMQ==}
     hasBin: true
 
   node-gyp-build@4.8.1:
@@ -13812,6 +14573,13 @@ packages:
     resolution: {integrity: sha512-wB3wfAxZpk2AzOfUMJNL+d36xothRSyj8EXOa4f6GMqYDN9BJaaSISbsk+wS9abmnebVw95C2Kb5t85UmpCxuw==}
     engines: {node: '>=4'}
 
+  p-defer@3.0.0:
+    resolution: {integrity: sha512-ugZxsxmtTln604yeYd29EGrNhazN2lywetzpKhfmQjW/VJmhpDmWbiX+h0zL8V91R0UXkhb3KtPmyq9PZw3aYw==}
+    engines: {node: '>=8'}
+
+  p-fifo@1.0.0:
+    resolution: {integrity: sha512-IjoCxXW48tqdtDFz6fqo5q1UfFVjjVZe8TC1QRflvNUJtNfCUhxOUw6MOVZhDPjqhSzc26xKdugsO17gmzd5+A==}
+
   p-filter@2.1.0:
     resolution: {integrity: sha512-ZBxxZ5sL2HghephhpGAQdoskxplTwr7ICaehZwLIlfL6acuVgZPm8yBNuRAFBGEqtD/hmUeq9eqLg2ys9Xr/yw==}
     engines: {node: '>=8'}
@@ -13902,6 +14670,9 @@ packages:
 
   parse-css-color@0.2.1:
     resolution: {integrity: sha512-bwS/GGIFV3b6KS4uwpzCFj4w297Yl3uqnSgIPsoQkx7GMLROXfMnWvxfNkL0oh8HVhZA4hvJoEoEIqonfJ3BWg==}
+
+  parse-duration@1.1.2:
+    resolution: {integrity: sha512-p8EIONG8L0u7f8GFgfVlL4n8rnChTt8O5FSxgxMz2tjc9FMP199wxVKVB6IbKx11uTbKHACSvaLVIKNnoeNR/A==}
 
   parse-entities@4.0.1:
     resolution: {integrity: sha512-SWzvYcSJh4d/SGLIOQfZ/CoNv6BTlI6YEQ7Nj82oDVnRpwe/Z/F1EMx42x3JAOwGBlCjeCH0BRJQbQ/opHL17w==}
@@ -14024,6 +14795,10 @@ packages:
   pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
     engines: {node: '>=0.12'}
+
+  peek-readable@4.1.0:
+    resolution: {integrity: sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg==}
+    engines: {node: '>=8'}
 
   periscopic@3.1.0:
     resolution: {integrity: sha512-vKiQ8RRtkl9P+r/+oefh25C3fhybptkHKCZSPlcXiJux2tJF55GnEj3BVn4A5gKfq9NWWXXrxkHBwVPUfH0opw==}
@@ -14503,6 +15278,14 @@ packages:
   proto-list@1.2.4:
     resolution: {integrity: sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==}
 
+  protobufjs@6.11.4:
+    resolution: {integrity: sha512-5kQWPaJHi1WoCpjTGszzQ32PG2F4+wRY6BmAT4Vfw56Q2FZ4YZzK20xUYQH4YkfehY1e6QSICrJquM6xXZNcrw==}
+    hasBin: true
+
+  protobufjs@7.5.4:
+    resolution: {integrity: sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==}
+    engines: {node: '>=12.0.0'}
+
   protons-runtime@5.2.2:
     resolution: {integrity: sha512-o97rNPN9pE3cxOxjs/waZNRKlbY/DR11oc20rUvarWZgFzQLLLzJU0RFh5JPi6GJCN67VGVn9/FDIEtFblfB3A==}
 
@@ -14638,6 +15421,10 @@ packages:
   r1csfile@0.0.48:
     resolution: {integrity: sha512-kHRkKUJNaor31l05f2+RFzvcH5XSa7OfEfd/l4hzjte6NL6fjRkSMfZ4BjySW9wmfdwPOtq3mXurzPvPGEf5Tw==}
 
+  rabin-wasm@0.1.5:
+    resolution: {integrity: sha512-uWgQTo7pim1Rnj5TuWcCewRDTf0PEFTSlaUjWP4eY9EbLV9em08v89oCz/WO+wRxpYuO36XEHp4wgYQnAgOHzA==}
+    hasBin: true
+
   radix3@1.1.2:
     resolution: {integrity: sha512-b484I/7b8rDEdSDKckSSBA8knMpcdsXudlE/LNL639wFoHKwLbEkQFZHWEYwDC0wa0FKUcCY+GAF73Z7wxNVFA==}
 
@@ -14744,6 +15531,9 @@ packages:
     peerDependencies:
       react-loadable: '*'
       webpack: '>=4.41.1 || 5.x'
+
+  react-native-fetch-api@3.0.0:
+    resolution: {integrity: sha512-g2rtqPjdroaboDKTsJCTlcmtw54E25OjyaunUP0anOZn4Fuo2IKs8BVfe02zVggA/UysbmfSnRJIqtNkAgggNA==}
 
   react-native-securerandom@0.1.1:
     resolution: {integrity: sha512-CozcCx0lpBLevxiXEb86kwLRalBCHNjiGPlw3P7Fi27U6ZLdfjOCNRHD1LtBKcvPvI3TvkBXB3GOtLvqaYJLGw==}
@@ -14895,6 +15685,14 @@ packages:
     resolution: {integrity: sha512-yjavECdqeZ3GLXNgRXgeQEdz9fvDDkNKyHnbHRFtOr7/LcfgBcmct7t/ET+HaCTqfh06OzoAxrkN/IfjJBVe+g==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
 
+  readable-stream@4.7.0:
+    resolution: {integrity: sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg==}
+    engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
+
+  readable-web-to-node-stream@3.0.4:
+    resolution: {integrity: sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw==}
+    engines: {node: '>=8'}
+
   readdirp@3.6.0:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
@@ -14905,6 +15703,9 @@ packages:
   readline@1.3.0:
     resolution: {integrity: sha512-k2d6ACCkiNYz222Fs/iNze30rRJ1iIicW7JuX/7/cozvih6YCkFZH+J6mAFDVgv0dRBaAyr4jDqC95R2y4IADg==}
 
+  readonly-date@1.0.0:
+    resolution: {integrity: sha512-tMKIV7hlk0h4mO3JTmmVuIlJVXjKk3Sep9Bf5OH0O+758ruuVkUy2J9SttDLm91IEX/WHlXPSpxMGjPj4beMIQ==}
+
   real-require@0.1.0:
     resolution: {integrity: sha512-r/H9MzAWtrv8aSVjPCMFpDMl5q66GqtmmRkRjpHTsp4zBAa+snZyiQNlMONiUmEJcsnaw0wCauJ2GWODr/aFkg==}
     engines: {node: '>= 12.13.0'}
@@ -14912,6 +15713,9 @@ packages:
   recast@0.21.5:
     resolution: {integrity: sha512-hjMmLaUXAm1hIuTqOdeYObMslq/q+Xff6QE3Y2P+uoHAg2nmVlLBps2hzh1UJDdMtDTMXOFewK6ky51JQIeECg==}
     engines: {node: '>= 4'}
+
+  receptacle@1.3.2:
+    resolution: {integrity: sha512-HrsFvqZZheusncQRiEE7GatOAETrARKV/lnfYicIm8lbvp/JQOdADOfhjBd2DajvoszEyxSM6RlAAIZgEoeu/A==}
 
   rechoir@0.6.2:
     resolution: {integrity: sha512-HFM8rkZ+i3zrV+4LQjwQ0W+ez98pApMGM3HUrN04j3CqzPOzl9nmP15Y8YXNm8QHGv/eacOVEjqhmWpkRV0NAw==}
@@ -15126,6 +15930,9 @@ packages:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
 
+  retimer@3.0.0:
+    resolution: {integrity: sha512-WKE0j11Pa0ZJI5YIk0nflGI7SQsfl2ljihVy7ogh7DeQSeYAUi0ubZ/yEueGtDfUPk6GH5LRw1hBdLq4IwUBWA==}
+
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
@@ -15290,6 +16097,10 @@ packages:
   secp256k1@5.0.0:
     resolution: {integrity: sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==}
     engines: {node: '>=14.0.0'}
+
+  secp256k1@5.0.1:
+    resolution: {integrity: sha512-lDFs9AAIaWP9UCdtWrotXWWF9t8PWgQDcxqgAnpM9rMqxb3Oaq2J0thzPVSxBwdJgyQtkU/sYtFtbM1RSt/iYA==}
+    engines: {node: '>=18.0.0'}
 
   section-matter@1.0.0:
     resolution: {integrity: sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==}
@@ -15491,6 +16302,11 @@ packages:
     engines: {node: '>=12.0.0', npm: '>=5.6.0'}
     hasBin: true
 
+  siwe-recap@0.0.2-alpha.0:
+    resolution: {integrity: sha512-xqFUnvrACWW/Q4s5HQ02avg8IyH2RcgkUzfvN4scYaaHErotLVtTGDZkSS0sn/oNK4MXRt83lTqredsvXgt8iA==}
+    peerDependencies:
+      ethers: ^5.5.1
+
   siwe@2.3.2:
     resolution: {integrity: sha512-aSf+6+Latyttbj5nMu6GF3doMfv2UYj83hhwZgUF20ky6fTS83uVhkQABdIVnEuS8y1bBdk7p6ltb9SmlhTTlA==}
     peerDependencies:
@@ -15589,9 +16405,13 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
+
+  sparse-array@1.3.2:
+    resolution: {integrity: sha512-ZT711fePGn3+kQyLuv1fpd3rNSkNF8vd5Kv2D+qnOANeyKs3fx6bUMGWRPvgTTcYV64QMqZKZwcuaQSP3AZ0tg==}
 
   spawn-command@0.0.2:
     resolution: {integrity: sha512-zC8zGoGkmc8J9ndvml8Xksr1Amk9qBujgbF0JAIWO7kXr43w0h/0GJNM/Vustixu+YE8N/MTrQ7N31FvHUACxQ==}
@@ -15695,6 +16515,9 @@ packages:
 
   stream-splicer@2.0.1:
     resolution: {integrity: sha512-Xizh4/NPuYSyAXyT7g8IvdJ9HJpxIGL9PjyhtywCZvvP0OPIdqyrr4dMikeuvY8xahpdKEBlBTySe583totajg==}
+
+  stream-to-it@0.2.4:
+    resolution: {integrity: sha512-4vEbkSs83OahpmBybNJXlJd7d6/RxzkkSdT3I0mnGt79Xd2Kk+e1JqbvAvsQfCeKj3aKb0QIWkyK3/n0j506vQ==}
 
   stream-transform@2.1.3:
     resolution: {integrity: sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==}
@@ -15826,6 +16649,14 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  strtok3@10.3.4:
+    resolution: {integrity: sha512-KIy5nylvC5le1OdaaoCJ07L+8iQzJHGH6pWDuzS+d07Cu7n1MZ2x26P8ZKIWfbK02+XIL8Mp4RkWeqdUCrDMfg==}
+    engines: {node: '>=18'}
+
+  strtok3@6.3.0:
+    resolution: {integrity: sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw==}
+    engines: {node: '>=10'}
+
   structured-headers@0.4.1:
     resolution: {integrity: sha512-0MP/Cxx5SzeeZ10p/bZI0S6MpgD+yxAhi1BOQ34jgnMXsCq3j1t6tQnZu+KdlL7dvJTLT3g9xN8tl10TqgFMcg==}
 
@@ -15938,6 +16769,10 @@ packages:
     resolution: {integrity: sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==}
     peerDependencies:
       react: ^16.11.0 || ^17.0.0 || ^18.0.0
+
+  symbol-observable@2.0.3:
+    resolution: {integrity: sha512-sQV7phh2WCYAn81oAkakC5qjq2Ml0g8ozqz03wOGnx9dDlG1de6yrF+0RAzSJD8fPUow3PTSMf2SAbOGxb93BA==}
+    engines: {node: '>=0.10'}
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
@@ -16099,6 +16934,9 @@ packages:
   thunky@1.1.0:
     resolution: {integrity: sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==}
 
+  timeout-abort-controller@3.0.0:
+    resolution: {integrity: sha512-O3e+2B8BKrQxU2YRyEjC/2yFdb33slI22WRdUaDx6rvysfi9anloNZyR2q0l6LnePo5qH7gSM7uZtvvwZbc2yA==}
+
   timers-browserify@1.4.2:
     resolution: {integrity: sha512-PIxwAupJZiYU4JmVZYwXp9FKsHMXb5h0ZEFyuXTAn8WLHOlcij+FEcbrvDsom1o5dr1YggEtFbECvGCW2sT53Q==}
     engines: {node: '>=0.6.0'}
@@ -16149,6 +16987,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  token-types@4.2.1:
+    resolution: {integrity: sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ==}
+    engines: {node: '>=10'}
+
+  token-types@6.1.1:
+    resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
+    engines: {node: '>=14.16'}
 
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
@@ -16244,8 +17090,14 @@ packages:
   tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
+  tslib@2.6.0:
+    resolution: {integrity: sha512-7At1WUettjcSRHXCyYtTselblcHl9PJFFVKiCAy/bY97+BPZXSQ2wbq0P9s8tK2G7dFQfNnlJnPAiArVBVBsfA==}
+
   tslib@2.6.2:
     resolution: {integrity: sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q==}
+
+  tslib@2.7.0:
+    resolution: {integrity: sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==}
 
   tslib@2.8.0:
     resolution: {integrity: sha512-jWVzBLplnCmoaTr13V9dYbiQ99wvZRd0vNWaDRg+aVYRcjDF3nDksxFDE/+fkXnKhpnUUkmx5pK/v8mCtLVqZA==}
@@ -16279,6 +17131,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  tweetnacl-util@0.13.5:
+    resolution: {integrity: sha512-/4Q3hpPFAnbBjNLLOmdTdyvInBfZcQBTWy+LWbypmWxAKwOpSQOyyv4ZZts4CoiYtS8Skyix5CkOWytf7XNK9A==}
 
   tweetnacl-util@0.15.1:
     resolution: {integrity: sha512-RKJBIj8lySrShN4w6i/BonWp2Z/uxwC3h4y7xsRrpP59ZboCd0GpEVsOnMDYLMmKBpYhb5TgHzZXy7wTfYFBRw==}
@@ -16368,6 +17223,9 @@ packages:
   typedarray@0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
+  typeforce@1.18.0:
+    resolution: {integrity: sha512-7uc1O8h1M1g0rArakJdf0uLRSSgFcYexrVoKo+bzJd32gd4gDy2L/Z+8/FjPnU9ydY3pEnVPtr9FyscYY60K1g==}
+
   typeorm@0.3.20:
     resolution: {integrity: sha512-sJ0T08dV5eoZroaq9uPKBoNcGslHBR4E4y+EBHs//SiGbblGe7IeduP/IH4ddCcj0qp3PHwDwGnuvqEAnKlq/Q==}
     engines: {node: '>=16.13.0'}
@@ -16444,6 +17302,10 @@ packages:
   ufo@1.5.3:
     resolution: {integrity: sha512-Y7HYmWaFwPUmkoQCUIAYpKqkOf+SbVj/2fJJZ4RJMCfZp0rTGwRbzQD+HghfnhKOjL9E01okqz+ncJskGYfBNw==}
 
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
+
   uint8arraylist@2.4.8:
     resolution: {integrity: sha512-vc1PlGOzglLF0eae1M8mLRTBivsvrGsdmJ5RbK3e+QRvRLOZfZhQROTwH/OfyF3+ZVUg9/8hE8bmKP2CvP9quQ==}
 
@@ -16459,8 +17321,8 @@ packages:
   uint8arrays@4.0.6:
     resolution: {integrity: sha512-4ZesjQhqOU2Ip6GPReIwN60wRxIupavL8T0Iy36BBHr2qyMrNxsPJvr7vpS4eFt8F8kSguWUPad6ZM9izs/vyw==}
 
-  uint8arrays@5.0.1:
-    resolution: {integrity: sha512-ND5RpJAnPgHmZT7hWD/2T4BwRp04j8NLKvMKC/7bhiEwEjUMkQ4kvBKiH6hOqbljd6qJ2xS8reL3vl1e33grOQ==}
+  uint8arrays@5.1.0:
+    resolution: {integrity: sha512-vA6nFepEmlSKkMBnLBaUMVvAC4G3CTmO58C12y4sq6WPDOR7mOFYOi7GlrQ4djeSbP6JG9Pv9tJDM97PedRSww==}
 
   umd@3.0.3:
     resolution: {integrity: sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==}
@@ -16782,6 +17644,14 @@ packages:
     resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
     engines: {node: '>= 0.4.0'}
 
+  uuid@10.0.0:
+    resolution: {integrity: sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==}
+    hasBin: true
+
+  uuid@13.0.0:
+    resolution: {integrity: sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==}
+    hasBin: true
+
   uuid@7.0.3:
     resolution: {integrity: sha512-DPSke0pXhTZgoF/d+WSt2QaKMCFSfx7QegxEWT+JOuHF5aWrKEn0G+ztjuJg/gG8/ItK+rbPCD/yNv8yyih6Cg==}
     hasBin: true
@@ -16817,6 +17687,15 @@ packages:
   validator@13.11.0:
     resolution: {integrity: sha512-Ii+sehpSfZy+At5nPdnyMhx78fEoPDkR2XW/zimHEL3MyGJQOCQ7WeP20jPYRz7ZCpcKLB21NxuXHF3bxjStBQ==}
     engines: {node: '>= 0.10'}
+
+  valtio@1.11.0:
+    resolution: {integrity: sha512-65Yd0yU5qs86b5lN1eu/nzcTgQ9/6YnD6iO+DDaDbQLn1Zv2w12Gwk43WkPlUBxk5wL/6cD5YMFf7kj6HZ1Kpg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      react: '>=16.8'
+    peerDependenciesMeta:
+      react:
+        optional: true
 
   valtio@1.11.2:
     resolution: {integrity: sha512-1XfIxnUXzyswPAPXo1P3Pdx2mq/pIqZICkWN60Hby0d9Iqb+MEIpqgYVlbflvHdrp2YR/q3jyKWRPJJ100yxaw==}
@@ -16995,6 +17874,9 @@ packages:
   web-streams-polyfill@4.0.0:
     resolution: {integrity: sha512-0zJXHRAYEjM2tUfZ2DiSOHAa2aw1tisnnhU3ufD57R8iefL+DcdJyRBRyJpG+NUimDgbTI/lH+gAE1PAvV3Cgw==}
     engines: {node: '>= 8'}
+
+  web-vitals@3.5.2:
+    resolution: {integrity: sha512-c0rhqNcHXRkY/ogGDJQxZ9Im9D19hDihbzSQJrsioex+KnFgmMzBiy57Z1EjkhX/+OjyBpclDCzz2ITtjokFmg==}
 
   web-worker@1.2.0:
     resolution: {integrity: sha512-PgF341avzqyx60neE9DD+XS26MMNMoUQRz9NOZwW32nPQrF6p77f1htcnjBSEV8BGMKZ16choqUG4hyI0Hx7mA==}
@@ -17323,6 +18205,18 @@ packages:
       utf-8-validate:
         optional: true
 
+  ws@8.17.1:
+    resolution: {integrity: sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
   ws@8.18.0:
     resolution: {integrity: sha512-8VbfWfHLbbwu3+N6OKsOMpBdT4kXPDDB9cJk2bJ6mh9ucxdlnNvH1e+roYkKmN9Nxw2yjz7VzeO9oOz2zJ04Pw==}
     engines: {node: '>=10.0.0'}
@@ -17385,6 +18279,9 @@ packages:
   xmlhttprequest-ssl@2.0.0:
     resolution: {integrity: sha512-QKxVRxiRACQcVuQEYFsI1hhkrMlrXHPegbbd1yn9UHOmRxY+si12nQYzri3vbzt8VdTTRviqcKxcyllFas5z2A==}
     engines: {node: '>=0.4.0'}
+
+  xstream@11.14.0:
+    resolution: {integrity: sha512-1bLb+kKKtKPbgTK6i/BaoAn03g47PpFstlbe1BA+y3pNS/LfvcaghS5BFf9+EE1J+KwSQsEpfJvFN5GqFtiNmw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -17668,6 +18565,8 @@ snapshots:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
+  '@assemblyscript/loader@0.9.4': {}
+
   '@astronautlabs/jsonpath@1.1.2(patch_hash=7tqhac4nd4eo2oclutqyg5v5xq)':
     dependencies:
       static-eval: 2.0.2
@@ -17732,7 +18631,7 @@ snapshots:
       '@babel/traverse': 7.24.5
       '@babel/types': 7.24.5
       convert-source-map: 2.0.0
-      debug: 4.3.4
+      debug: 4.3.7
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17923,7 +18822,7 @@ snapshots:
       '@babel/core': 7.23.2
       '@babel/helper-compilation-targets': 7.23.6
       '@babel/helper-plugin-utils': 7.24.5
-      debug: 4.3.4
+      debug: 4.3.7
       lodash.debounce: 4.0.8
       resolve: 1.22.8
     transitivePeerDependencies:
@@ -20773,7 +21672,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.22.6
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20788,7 +21687,7 @@ snapshots:
       '@babel/helper-split-export-declaration': 7.24.5
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
-      debug: 4.3.4
+      debug: 4.3.7
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
@@ -20861,6 +21760,10 @@ snapshots:
     optional: true
 
   '@bitauth/libauth@1.19.1': {}
+
+  '@borewit/text-codec@0.1.1': {}
+
+  '@bufbuild/protobuf@2.10.2': {}
 
   '@cef-ebsi/ebsi-did-resolver@3.2.0':
     dependencies:
@@ -21215,6 +22118,126 @@ snapshots:
       human-id: 1.0.2
       prettier: 2.8.8
 
+  '@cheqd/did-provider-cheqd@4.6.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(node-fetch@2.7.0(encoding@0.1.13))(react@18.3.1)(typescript@5.4.5)(web-streams-polyfill@4.0.0)':
+    dependencies:
+      '@cheqd/sdk': 5.3.7(bufferutil@4.0.8)(debug@4.4.3)
+      '@cheqd/ts-proto': 4.2.0
+      '@cosmjs/amino': 0.36.2
+      '@cosmjs/crypto': 0.36.2
+      '@cosmjs/proto-signing': 0.36.2
+      '@cosmjs/stargate': 0.36.2(bufferutil@4.0.8)
+      '@cosmjs/utils': 0.36.2
+      '@digitalbazaar/bitstring': 3.1.0
+      '@digitalbazaar/vc-status-list': 8.0.1(web-streams-polyfill@4.0.0)
+      '@lit-protocol/auth-helpers': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts-sdk': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/encryption-v2': '@lit-protocol/encryption@2.2.63(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))'
+      '@lit-protocol/lit-node-client': 6.11.5(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)(typescript@5.4.5)
+      '@lit-protocol/lit-node-client-v2': '@lit-protocol/lit-node-client@2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)'
+      '@lit-protocol/lit-node-client-v3': '@lit-protocol/lit-node-client@3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)'
+      '@veramo/core': 6.0.0
+      '@veramo/did-manager': 6.0.0
+      '@veramo/did-provider-key': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)
+      '@veramo/key-manager': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
+      '@veramo/utils': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
+      debug: 4.4.3
+      did-jwt: 8.0.18
+      did-resolver: 4.1.0
+      ethers: 6.16.0(bufferutil@4.0.8)
+      generate-password: 1.7.1
+      uint8arrays: 5.1.0
+      uuid: 13.0.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - node-fetch
+      - react
+      - supports-color
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+      - web-streams-polyfill
+
+  '@cheqd/sdk@5.3.7(bufferutil@4.0.8)(debug@4.4.3)':
+    dependencies:
+      '@cheqd/ts-proto': 4.2.0
+      '@cheqd/ts-proto-cjs': '@cheqd/ts-proto@2.5.0'
+      '@cosmjs/amino': 0.36.2
+      '@cosmjs/amino-cjs': '@cosmjs/amino@0.30.1'
+      '@cosmjs/crypto': 0.36.2
+      '@cosmjs/crypto-cjs': '@cosmjs/crypto@0.30.1'
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/encoding-cjs': '@cosmjs/encoding@0.30.1'
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/math-cjs': '@cosmjs/math@0.30.1'
+      '@cosmjs/proto-signing': 0.36.2
+      '@cosmjs/proto-signing-cjs': '@cosmjs/proto-signing@0.30.1'
+      '@cosmjs/stargate': 0.36.2(bufferutil@4.0.8)
+      '@cosmjs/stargate-cjs': '@cosmjs/stargate@0.30.1(bufferutil@4.0.8)(debug@4.4.3)'
+      '@cosmjs/tendermint-rpc': 0.36.2(bufferutil@4.0.8)
+      '@cosmjs/tendermint-rpc-cjs': '@cosmjs/tendermint-rpc@0.30.1(bufferutil@4.0.8)(debug@4.4.3)'
+      '@cosmjs/utils': 0.36.2
+      '@cosmjs/utils-cjs': '@cosmjs/utils@0.30.1'
+      '@stablelib/ed25519': 2.0.2
+      '@stablelib/ed25519-cjs': '@stablelib/ed25519@1.0.3'
+      '@types/secp256k1': 4.0.6
+      '@types/secp256k1-cjs': '@types/secp256k1@4.0.6'
+      cosmjs-types: 0.10.1
+      cosmjs-types-cjs: cosmjs-types@0.7.2
+      did-jwt: 8.0.18
+      did-jwt-cjs: did-jwt@8.0.18
+      did-resolver: 4.1.0
+      did-resolver-cjs: did-resolver@4.1.0
+      exponential-backoff: 3.1.3
+      exponential-backoff-cjs: exponential-backoff@3.1.3
+      file-type: 21.1.1
+      file-type-cjs: file-type@16.5.4
+      long-cjs: long@4.0.0
+      multiformats: 13.4.2
+      multiformats-cjs: multiformats@9.9.0
+      secp256k1: 5.0.1
+      secp256k1-cjs: secp256k1@5.0.1
+      uint8arrays: 5.1.0
+      uint8arrays-cjs: uint8arrays@3.1.1
+      uuid: 13.0.0
+      uuid-cjs: uuid@10.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - supports-color
+      - utf-8-validate
+
+  '@cheqd/ts-proto@2.5.0':
+    dependencies:
+      '@bufbuild/protobuf': 2.10.2
+      long: 5.3.2
+      protobufjs: 7.5.4
+
+  '@cheqd/ts-proto@4.2.0':
+    dependencies:
+      '@bufbuild/protobuf': 2.10.2
+      long: 5.3.2
+      protobufjs: 7.5.4
+
   '@coinbase/wallet-sdk@3.9.1':
     dependencies:
       bn.js: 5.2.1
@@ -21253,7 +22276,7 @@ snapshots:
   '@commitlint/config-validator@19.0.3':
     dependencies:
       '@commitlint/types': 19.0.3
-      ajv: 8.13.0
+      ajv: 8.17.1
 
   '@commitlint/ensure@19.0.3':
     dependencies:
@@ -21343,7 +22366,190 @@ snapshots:
       '@types/conventional-commits-parser': 5.0.0
       chalk: 5.3.0
 
+  '@confio/ics23@0.6.8':
+    dependencies:
+      '@noble/hashes': 1.8.0
+      protobufjs: 6.11.4
+
   '@corex/deepmerge@4.0.43': {}
+
+  '@cosmjs/amino@0.30.1':
+    dependencies:
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@cosmjs/math': 0.30.1
+      '@cosmjs/utils': 0.30.1
+
+  '@cosmjs/amino@0.36.2':
+    dependencies:
+      '@cosmjs/crypto': 0.36.2
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/utils': 0.36.2
+
+  '@cosmjs/crypto@0.30.1':
+    dependencies:
+      '@cosmjs/encoding': 0.30.1
+      '@cosmjs/math': 0.30.1
+      '@cosmjs/utils': 0.30.1
+      '@noble/hashes': 1.8.0
+      bn.js: 5.2.1
+      elliptic: 6.6.1
+      libsodium-wrappers: 0.7.15
+
+  '@cosmjs/crypto@0.36.2':
+    dependencies:
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/utils': 0.36.2
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.9.7
+      '@noble/hashes': 1.8.0
+      hash-wasm: 4.12.0
+
+  '@cosmjs/encoding@0.30.1':
+    dependencies:
+      base64-js: 1.5.1
+      bech32: 1.1.4
+      readonly-date: 1.0.0
+
+  '@cosmjs/encoding@0.36.2':
+    dependencies:
+      base64-js: 1.5.1
+      bech32: 1.1.4
+      readonly-date: 1.0.0
+
+  '@cosmjs/json-rpc@0.30.1':
+    dependencies:
+      '@cosmjs/stream': 0.30.1
+      xstream: 11.14.0
+
+  '@cosmjs/json-rpc@0.36.2':
+    dependencies:
+      '@cosmjs/stream': 0.36.2
+      xstream: 11.14.0
+
+  '@cosmjs/math@0.30.1':
+    dependencies:
+      bn.js: 5.2.1
+
+  '@cosmjs/math@0.36.2': {}
+
+  '@cosmjs/proto-signing@0.30.1':
+    dependencies:
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@cosmjs/math': 0.30.1
+      '@cosmjs/utils': 0.30.1
+      cosmjs-types: 0.7.2
+      long: 4.0.0
+
+  '@cosmjs/proto-signing@0.36.2':
+    dependencies:
+      '@cosmjs/amino': 0.36.2
+      '@cosmjs/crypto': 0.36.2
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/utils': 0.36.2
+      cosmjs-types: 0.10.1
+
+  '@cosmjs/socket@0.30.1(bufferutil@4.0.8)':
+    dependencies:
+      '@cosmjs/stream': 0.30.1
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.8))
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cosmjs/socket@0.36.2(bufferutil@4.0.8)':
+    dependencies:
+      '@cosmjs/stream': 0.36.2
+      isomorphic-ws: 4.0.1(ws@7.5.10(bufferutil@4.0.8))
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cosmjs/stargate@0.30.1(bufferutil@4.0.8)(debug@4.4.3)':
+    dependencies:
+      '@confio/ics23': 0.6.8
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@cosmjs/math': 0.30.1
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stream': 0.30.1
+      '@cosmjs/tendermint-rpc': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      '@cosmjs/utils': 0.30.1
+      cosmjs-types: 0.7.2
+      long: 4.0.0
+      protobufjs: 6.11.4
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@cosmjs/stargate@0.36.2(bufferutil@4.0.8)':
+    dependencies:
+      '@cosmjs/amino': 0.36.2
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/proto-signing': 0.36.2
+      '@cosmjs/stream': 0.36.2
+      '@cosmjs/tendermint-rpc': 0.36.2(bufferutil@4.0.8)
+      '@cosmjs/utils': 0.36.2
+      cosmjs-types: 0.10.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cosmjs/stream@0.30.1':
+    dependencies:
+      xstream: 11.14.0
+
+  '@cosmjs/stream@0.36.2':
+    dependencies:
+      xstream: 11.14.0
+
+  '@cosmjs/tendermint-rpc@0.30.1(bufferutil@4.0.8)(debug@4.4.3)':
+    dependencies:
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@cosmjs/json-rpc': 0.30.1
+      '@cosmjs/math': 0.30.1
+      '@cosmjs/socket': 0.30.1(bufferutil@4.0.8)
+      '@cosmjs/stream': 0.30.1
+      '@cosmjs/utils': 0.30.1
+      axios: 0.21.4(debug@4.4.3)
+      readonly-date: 1.0.0
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - utf-8-validate
+
+  '@cosmjs/tendermint-rpc@0.36.2(bufferutil@4.0.8)':
+    dependencies:
+      '@cosmjs/crypto': 0.36.2
+      '@cosmjs/encoding': 0.36.2
+      '@cosmjs/json-rpc': 0.36.2
+      '@cosmjs/math': 0.36.2
+      '@cosmjs/socket': 0.36.2(bufferutil@4.0.8)
+      '@cosmjs/stream': 0.36.2
+      '@cosmjs/utils': 0.36.2
+      readonly-date: 1.0.0
+      xstream: 11.14.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@cosmjs/utils@0.30.1': {}
+
+  '@cosmjs/utils@0.36.2': {}
 
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
@@ -21403,7 +22609,7 @@ snapshots:
   '@didtools/pkh-solana@0.1.1':
     dependencies:
       '@didtools/cacao': 2.1.0
-      '@noble/curves': 1.4.0
+      '@noble/curves': 1.6.0
       '@stablelib/random': 1.0.2
       caip: 1.1.0
       uint8arrays: 4.0.6
@@ -21423,8 +22629,8 @@ snapshots:
   '@didtools/pkh-tezos@0.2.2':
     dependencies:
       '@didtools/cacao': 2.1.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
       '@stablelib/random': 1.0.2
       caip: 1.1.0
       uint8arrays: 4.0.6
@@ -21432,6 +22638,13 @@ snapshots:
   '@didtools/siwx@1.0.0':
     dependencies:
       codeco: 1.2.0
+
+  '@digitalbazaar/bitstring@3.1.0':
+    dependencies:
+      base64url-universal: 2.0.0
+      pako: 2.1.0
+
+  '@digitalbazaar/credentials-context@3.2.0': {}
 
   '@digitalbazaar/http-client@1.2.0(patch_hash=yl3b524jp4dtc7mdahww7krgi4)(web-streams-polyfill@4.0.0)':
     dependencies:
@@ -21456,6 +22669,26 @@ snapshots:
       undici: 6.20.1
 
   '@digitalbazaar/security-context@1.0.1': {}
+
+  '@digitalbazaar/vc-status-list-context@3.1.1': {}
+
+  '@digitalbazaar/vc-status-list@8.0.1(web-streams-polyfill@4.0.0)':
+    dependencies:
+      '@digitalbazaar/bitstring': 3.1.0
+      '@digitalbazaar/credentials-context': 3.2.0
+      '@digitalbazaar/vc': 7.2.0(web-streams-polyfill@4.0.0)
+      '@digitalbazaar/vc-status-list-context': 3.1.1
+    transitivePeerDependencies:
+      - web-streams-polyfill
+
+  '@digitalbazaar/vc@7.2.0(web-streams-polyfill@4.0.0)':
+    dependencies:
+      '@digitalbazaar/credentials-context': 3.2.0
+      ed25519-signature-2018-context: 1.1.0
+      jsonld: 8.3.3(web-streams-polyfill@4.0.0)
+      jsonld-signatures: 11.5.0(web-streams-polyfill@4.0.0)
+    transitivePeerDependencies:
+      - web-streams-polyfill
 
   '@digitalcredentials/base58-universal@1.0.1': {}
 
@@ -21519,10 +22752,10 @@ snapshots:
       - react-native
       - web-streams-polyfill
 
-  '@digitalcredentials/jsonld-signatures@9.4.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@digitalcredentials/jsonld-signatures@9.4.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@digitalbazaar/security-context': 1.0.1
-      '@digitalcredentials/jsonld': 6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+      '@digitalcredentials/jsonld': 6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
       fast-text-encoding: 1.0.6
       isomorphic-webcrypto: 2.3.8(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
       serialize-error: 8.1.0
@@ -21545,7 +22778,7 @@ snapshots:
       - react-native
       - web-streams-polyfill
 
-  '@digitalcredentials/jsonld@5.2.2(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@digitalcredentials/jsonld@5.2.2(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@digitalcredentials/http-client': 1.2.2(web-streams-polyfill@4.0.0)
       '@digitalcredentials/rdf-canonize': 1.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
@@ -21570,7 +22803,7 @@ snapshots:
       - react-native
       - web-streams-polyfill
 
-  '@digitalcredentials/jsonld@6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@digitalcredentials/jsonld@6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@digitalcredentials/http-client': 1.2.2(web-streams-polyfill@4.0.0)
       '@digitalcredentials/rdf-canonize': 1.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
@@ -22213,7 +23446,7 @@ snapshots:
   '@docusaurus/theme-translations@3.3.2':
     dependencies:
       fs-extra: 11.2.0
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@docusaurus/types@3.3.2(@swc/core@1.5.5(@swc/helpers@0.5.11))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -22289,7 +23522,7 @@ snapshots:
 
   '@emnapi/runtime@1.1.1':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.0
     optional: true
 
   '@emotion/babel-plugin@11.11.0':
@@ -22981,7 +24214,7 @@ snapshots:
       chalk: 4.1.2
       ci-info: 3.9.0
       connect: 3.7.0
-      debug: 4.3.7
+      debug: 4.4.3
       env-editor: 0.4.2
       fast-glob: 3.3.2
       find-yarn-workspace-root: 2.0.0
@@ -23050,7 +24283,7 @@ snapshots:
       '@expo/plist': 0.1.3
       '@expo/sdk-runtime-versions': 1.0.0
       chalk: 4.1.2
-      debug: 4.3.7
+      debug: 4.4.3
       find-up: 5.0.0
       getenv: 1.0.0
       glob: 7.1.6
@@ -23101,7 +24334,7 @@ snapshots:
   '@expo/env@0.3.0':
     dependencies:
       chalk: 4.1.2
-      debug: 4.3.7
+      debug: 4.4.3
       dotenv: 16.4.5
       dotenv-expand: 11.0.6
       getenv: 1.0.0
@@ -23140,7 +24373,7 @@ snapshots:
       '@expo/json-file': 8.3.3
       '@expo/spawn-async': 1.7.2
       chalk: 4.1.2
-      debug: 4.3.7
+      debug: 4.4.3
       find-yarn-workspace-root: 2.0.0
       fs-extra: 9.1.0
       getenv: 1.0.0
@@ -23186,7 +24419,7 @@ snapshots:
       '@expo/image-utils': 0.5.1(encoding@0.1.13)
       '@expo/json-file': 8.3.3
       '@react-native/normalize-colors': 0.74.88
-      debug: 4.3.7
+      debug: 4.4.3
       expo-modules-autolinking: 1.11.1
       fs-extra: 9.1.0
       resolve-from: 5.0.0
@@ -23272,22 +24505,22 @@ snapshots:
   '@formatjs/ecma402-abstract@1.18.2':
     dependencies:
       '@formatjs/intl-localematcher': 0.5.4
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@formatjs/fast-memoize@2.2.0':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@formatjs/icu-messageformat-parser@2.7.6':
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/icu-skeleton-parser': 1.8.0
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@formatjs/icu-skeleton-parser@1.8.0':
     dependencies:
       '@formatjs/ecma402-abstract': 1.18.2
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@formatjs/intl-localematcher@0.2.32':
     dependencies:
@@ -23295,7 +24528,7 @@ snapshots:
 
   '@formatjs/intl-localematcher@0.5.4':
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@gar/promisify@1.1.3': {}
 
@@ -23478,6 +24711,11 @@ snapshots:
   '@ioredis/commands@1.2.0':
     optional: true
 
+  '@ipld/dag-cbor@6.0.15':
+    dependencies:
+      cborg: 1.10.2
+      multiformats: 9.9.0
+
   '@ipld/dag-cbor@7.0.3':
     dependencies:
       cborg: 1.10.2
@@ -23487,6 +24725,15 @@ snapshots:
     dependencies:
       cborg: 2.0.3
       multiformats: 12.1.3
+
+  '@ipld/dag-json@8.0.11':
+    dependencies:
+      cborg: 1.10.2
+      multiformats: 9.9.0
+
+  '@ipld/dag-pb@2.1.18':
+    dependencies:
+      multiformats: 9.9.0
 
   '@ipld/dag-pb@4.0.8':
     dependencies:
@@ -23534,7 +24781,7 @@ snapshots:
     dependencies:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       jest-mock: 29.7.0
 
   '@jest/expect-utils@29.7.0':
@@ -23552,7 +24799,7 @@ snapshots:
     dependencies:
       '@jest/types': 29.6.3
       '@sinonjs/fake-timers': 10.3.0
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       jest-message-util: 29.7.0
       jest-mock: 29.7.0
       jest-util: 29.7.0
@@ -23658,7 +24905,7 @@ snapshots:
       '@jest/schemas': 29.6.3
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       '@types/yargs': 17.0.29
       chalk: 4.1.2
 
@@ -23712,6 +24959,1191 @@ snapshots:
   '@leichtgewicht/ip-codec@2.0.5': {}
 
   '@lit-labs/ssr-dom-shim@1.2.0': {}
+
+  '@lit-protocol/access-control-conditions@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/access-control-conditions@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/access-control-conditions@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/accs-schemas@0.0.19':
+    dependencies:
+      ajv: 8.17.1
+
+  '@lit-protocol/accs-schemas@0.0.3':
+    dependencies:
+      ajv: 8.17.1
+
+  '@lit-protocol/auth-browser@2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      '@walletconnect/ethereum-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.13.5
+      util: 0.12.5
+      web-vitals: 3.5.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@lit-protocol/auth-browser@3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      '@walletconnect/ethereum-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.13.5
+      uint8arrays: 4.0.6
+      util: 0.12.5
+      web-vitals: 3.5.2
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@lit-protocol/auth-browser@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/wallet': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc-browser': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/auth-helpers@2.2.63(ethers@5.7.2(bufferutil@4.0.8))':
+    dependencies:
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - ethers
+
+  '@lit-protocol/auth-helpers@3.1.4(ethers@5.7.2(bufferutil@4.0.8))':
+    dependencies:
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - ethers
+
+  '@lit-protocol/auth-helpers@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/access-control-conditions': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.6.0
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/bls-sdk@2.2.63':
+    dependencies:
+      pako: 2.1.0
+      tslib: 2.8.0
+
+  '@lit-protocol/bls-sdk@3.1.4':
+    dependencies:
+      pako: 2.1.0
+      tslib: 2.8.0
+
+  '@lit-protocol/bls-sdk@6.11.5':
+    dependencies:
+      tslib: 1.14.1
+      util: 0.12.5
+
+  '@lit-protocol/constants@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/constants@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/constants@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/contracts-sdk@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      bs58: 5.0.0
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      multiformats: 9.9.0
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/contracts-sdk@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      process: 0.11.10
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/contracts@0.0.63(typescript@5.4.5)':
+    dependencies:
+      typescript: 5.4.5
+
+  '@lit-protocol/core@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/access-control-conditions': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 2.2.63
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 2.2.63
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 2.2.63
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/core@3.1.4(bufferutil@4.0.8)(encoding@0.1.13)':
+    dependencies:
+      '@lit-protocol/access-control-conditions': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 3.1.4
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/contracts-sdk': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/ecdsa-sdk': 3.1.4
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 3.1.4
+      '@lit-protocol/sev-snp-utils-sdk': 3.1.4(encoding@0.1.13)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      bs58: 5.0.0
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      multiformats: 12.1.3
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@lit-protocol/core@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/access-control-conditions': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/contracts-sdk': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/crypto': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/ecdsa-sdk': 6.11.5
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/nacl': 6.11.5
+      '@lit-protocol/sev-snp-utils-sdk': 6.11.5
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      bs58: 5.0.0
+      cross-fetch: 3.1.4
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      multiformats: 9.9.0
+      pako: 1.0.11
+      process: 0.11.10
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/crypto@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 2.2.63
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 2.2.63
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 2.2.63
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/crypto@3.1.4(bufferutil@4.0.8)(encoding@0.1.13)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 3.1.4
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 3.1.4
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 3.1.4
+      '@lit-protocol/sev-snp-utils-sdk': 3.1.4(encoding@0.1.13)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - utf-8-validate
+
+  '@lit-protocol/crypto@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/ecdsa-sdk': 6.11.5
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/nacl': 6.11.5
+      '@lit-protocol/sev-snp-utils-sdk': 6.11.5
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      cross-fetch: 3.1.4
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      pako: 1.0.11
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/ecdsa-sdk@2.2.63':
+    dependencies:
+      tslib: 2.8.0
+
+  '@lit-protocol/ecdsa-sdk@3.1.4':
+    dependencies:
+      pako: 2.1.0
+      tslib: 2.8.0
+
+  '@lit-protocol/ecdsa-sdk@6.11.5':
+    dependencies:
+      tslib: 1.14.1
+      util: 0.12.5
+
+  '@lit-protocol/encryption@2.2.63(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 2.2.63
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 2.2.63
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 2.2.63
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - node-fetch
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/encryption@3.1.4(bufferutil@4.0.8)(encoding@0.1.13)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 3.1.4
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/ecdsa-sdk': 3.1.4
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 3.1.4
+      '@lit-protocol/sev-snp-utils-sdk': 3.1.4(encoding@0.1.13)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      jszip: 3.10.1
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/encryption@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/crypto': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/ecdsa-sdk': 6.11.5
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/nacl': 6.11.5
+      '@lit-protocol/sev-snp-utils-sdk': 6.11.5
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      cross-fetch: 3.1.4
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      pako: 1.0.11
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client-nodejs@2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      '@lit-protocol/access-control-conditions': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 2.2.63
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/core': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 2.2.63
+      '@lit-protocol/encryption': 2.2.63(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      '@lit-protocol/lit-third-party-libs': 2.2.63(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 2.2.63
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      blockstore-core: 3.0.0
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      jszip: 3.10.1
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client-nodejs@3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      '@lit-protocol/access-control-conditions': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 3.1.4
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/contracts-sdk': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/core': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/crypto': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/ecdsa-sdk': 3.1.4
+      '@lit-protocol/encryption': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/lit-third-party-libs': 3.1.4(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 3.1.4
+      '@lit-protocol/sev-snp-utils-sdk': 3.1.4(encoding@0.1.13)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      blockstore-core: 3.0.0
+      bs58: 5.0.0
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      jose: 4.15.4
+      jszip: 3.10.1
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      multiformats: 12.1.3
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client-nodejs@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@ethersproject/transactions': 5.7.0
+      '@lit-protocol/access-control-conditions': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/auth-helpers': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/contracts-sdk': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/core': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/crypto': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/ecdsa-sdk': 6.11.5
+      '@lit-protocol/encryption': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc-browser': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/nacl': 6.11.5
+      '@lit-protocol/sev-snp-utils-sdk': 6.11.5
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      bs58: 5.0.0
+      cross-fetch: 3.1.4
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      multiformats: 9.9.0
+      pako: 1.0.11
+      process: 0.11.10
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client@2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      '@lit-protocol/access-control-conditions': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/auth-browser': 2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 2.2.63
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/core': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/crypto': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/ecdsa-sdk': 2.2.63
+      '@lit-protocol/encryption': 2.2.63(bufferutil@4.0.8)(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      '@lit-protocol/lit-node-client-nodejs': 2.2.63(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/lit-third-party-libs': 2.2.63(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/misc': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 2.2.63
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      '@walletconnect/ethereum-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+      blockstore-core: 3.0.0
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      jszip: 3.10.1
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - debug
+      - encoding
+      - ioredis
+      - react
+      - supports-color
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client@3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      '@lit-protocol/access-control-conditions': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-browser': 3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/bls-sdk': 3.1.4
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/contracts-sdk': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/core': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/crypto': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/ecdsa-sdk': 3.1.4
+      '@lit-protocol/encryption': 3.1.4(bufferutil@4.0.8)(encoding@0.1.13)
+      '@lit-protocol/lit-node-client-nodejs': 3.1.4(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/lit-third-party-libs': 3.1.4(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/misc-browser': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/nacl': 3.1.4
+      '@lit-protocol/sev-snp-utils-sdk': 3.1.4(encoding@0.1.13)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      '@walletconnect/ethereum-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      blockstore-core: 3.0.0
+      bs58: 5.0.0
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      ipfs-http-client: 56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      jose: 4.15.4
+      jszip: 3.10.1
+      lit-siwe: 1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0)
+      multiformats: 12.1.3
+      node-fetch: 2.7.0(encoding@0.1.13)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@ethersproject/contracts'
+      - '@ethersproject/hash'
+      - '@ethersproject/providers'
+      - '@ethersproject/wallet'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - debug
+      - encoding
+      - ioredis
+      - react
+      - supports-color
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@lit-protocol/lit-node-client@6.11.5(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)(react@18.3.1)(typescript@5.4.5)':
+    dependencies:
+      '@cosmjs/amino': 0.30.1
+      '@cosmjs/crypto': 0.30.1
+      '@cosmjs/encoding': 0.30.1
+      '@ethersproject/abi': 5.7.0
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/bytes': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@ethersproject/strings': 5.7.0
+      '@ethersproject/transactions': 5.7.0
+      '@ethersproject/wallet': 5.7.0
+      '@lit-protocol/access-control-conditions': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/auth-browser': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/auth-helpers': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/bls-sdk': 6.11.5
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/contracts-sdk': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/core': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/crypto': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/ecdsa-sdk': 6.11.5
+      '@lit-protocol/encryption': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/lit-node-client-nodejs': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/misc-browser': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/nacl': 6.11.5
+      '@lit-protocol/sev-snp-utils-sdk': 6.11.5
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@walletconnect/ethereum-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+      ajv: 8.17.1
+      bitcoinjs-lib: 6.1.7
+      bs58: 5.0.0
+      cross-fetch: 3.1.4
+      date-and-time: 2.4.3
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jose: 4.15.4
+      jszip: 3.10.1
+      multiformats: 9.9.0
+      pako: 1.0.11
+      process: 0.11.10
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tweetnacl: 1.0.3
+      tweetnacl-util: 0.15.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - react
+      - typescript
+      - uWebSockets.js
+      - utf-8-validate
+
+  '@lit-protocol/lit-third-party-libs@2.2.63(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      blockstore-core: 3.0.0
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/lit-third-party-libs@3.1.4(bufferutil@4.0.8)(debug@4.4.3)(encoding@0.1.13)':
+    dependencies:
+      '@cosmjs/proto-signing': 0.30.1
+      '@cosmjs/stargate': 0.30.1(bufferutil@4.0.8)(debug@4.4.3)
+      blockstore-core: 3.0.0
+      ipfs-unixfs-importer: 12.0.1(encoding@0.1.13)
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - debug
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@lit-protocol/logger@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/logger@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/misc-browser@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 2.2.63
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/misc-browser@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 3.1.4
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/misc-browser@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      '@lit-protocol/uint8arrays': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/misc@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 2.2.63(bufferutil@4.0.8)
+      '@lit-protocol/types': 2.2.63(bufferutil@4.0.8)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/misc@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      '@lit-protocol/constants': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/logger': 3.1.4(bufferutil@4.0.8)
+      '@lit-protocol/types': 3.1.4(bufferutil@4.0.8)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/misc@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/constants': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      '@lit-protocol/logger': 6.11.5(bufferutil@4.0.8)(typescript@5.4.5)
+      '@lit-protocol/types': 6.11.5(bufferutil@4.0.8)
+      ajv: 8.17.1
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+      util: 0.12.5
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
+
+  '@lit-protocol/nacl@2.2.63':
+    dependencies:
+      tslib: 2.8.0
+
+  '@lit-protocol/nacl@3.1.4':
+    dependencies:
+      tslib: 2.8.0
+
+  '@lit-protocol/nacl@6.11.5':
+    dependencies:
+      tslib: 1.14.1
+
+  '@lit-protocol/sev-snp-utils-sdk@3.1.4(encoding@0.1.13)':
+    dependencies:
+      '@lit-protocol/uint8arrays': 3.1.4
+      node-fetch: 2.7.0(encoding@0.1.13)
+      pako: 2.1.0
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@lit-protocol/sev-snp-utils-sdk@6.11.5':
+    dependencies:
+      cross-fetch: 3.1.4
+      tslib: 1.14.1
+
+  '@lit-protocol/types@2.2.63(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/auth-helpers': 2.2.63(ethers@5.7.2(bufferutil@4.0.8))
+      ethers: 5.7.2(bufferutil@4.0.8)
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/types@3.1.4(bufferutil@4.0.8)':
+    dependencies:
+      '@lit-protocol/accs-schemas': 0.0.3
+      '@lit-protocol/auth-helpers': 3.1.4(ethers@5.7.2(bufferutil@4.0.8))
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      siwe-recap: 0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 2.8.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/types@6.11.5(bufferutil@4.0.8)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@lit-protocol/uint8arrays@2.2.63':
+    dependencies:
+      tslib: 2.8.0
+
+  '@lit-protocol/uint8arrays@3.1.4':
+    dependencies:
+      tslib: 2.8.0
+
+  '@lit-protocol/uint8arrays@6.11.5(bufferutil@4.0.8)(typescript@5.4.5)':
+    dependencies:
+      '@ethersproject/abstract-provider': 5.7.0
+      '@lit-protocol/accs-schemas': 0.0.19
+      '@lit-protocol/contracts': 0.0.63(typescript@5.4.5)
+      ethers: 5.7.2(bufferutil@4.0.8)
+      jszip: 3.10.1
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+      tslib: 1.14.1
+    transitivePeerDependencies:
+      - bufferutil
+      - typescript
+      - utf-8-validate
 
   '@lit/reactive-element@1.6.3':
     dependencies:
@@ -24085,14 +26517,14 @@ snapshots:
   '@metamask/scure-bip39@2.1.1':
     dependencies:
       '@noble/hashes': 1.3.3
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.9
 
   '@metamask/sdk-communication-layer@0.18.5(cross-fetch@4.0.0(patch_hash=o37ixiuozlaw3unzpuuojolyvy)(encoding@0.1.13))(eciesjs@0.3.18)(eventemitter2@6.4.9)(readable-stream@3.6.2)(socket.io-client@4.7.5(bufferutil@4.0.8))':
     dependencies:
       bufferutil: 4.0.8
       cross-fetch: 4.0.0(patch_hash=o37ixiuozlaw3unzpuuojolyvy)(encoding@0.1.13)
       date-fns: 2.30.0
-      debug: 4.3.4
+      debug: 4.3.7
       eciesjs: 0.3.18
       eventemitter2: 6.4.9
       readable-stream: 3.6.2
@@ -24121,7 +26553,7 @@ snapshots:
       '@types/dom-screen-wake-lock': 1.0.3
       bowser: 2.11.0
       cross-fetch: 4.0.0(patch_hash=o37ixiuozlaw3unzpuuojolyvy)(encoding@0.1.13)
-      debug: 4.3.4
+      debug: 4.3.7
       eciesjs: 0.3.18
       eth-rpc-errors: 4.0.3
       eventemitter2: 6.4.9
@@ -24349,7 +26781,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       '@scure/base': 1.1.9
       '@types/debug': 4.1.12
       debug: 4.3.7
@@ -24363,7 +26795,7 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@types/debug': 4.1.12
-      debug: 4.3.7
+      debug: 4.4.3
       semver: 7.6.3
       superstruct: 1.0.4
     transitivePeerDependencies:
@@ -24374,7 +26806,7 @@ snapshots:
       '@ethereumjs/tx': 4.2.0
       '@noble/hashes': 1.4.0
       '@types/debug': 4.1.10
-      debug: 4.3.4
+      debug: 4.3.7
       semver: 7.6.2
       superstruct: 1.0.3
     transitivePeerDependencies:
@@ -24384,10 +26816,10 @@ snapshots:
     dependencies:
       '@ethereumjs/tx': 4.2.0
       '@metamask/superstruct': 3.1.0
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.3.7
       pony-cause: 2.1.10
       semver: 7.6.2
       uuid: 9.0.1
@@ -24454,6 +26886,11 @@ snapshots:
       tslib: 2.8.0
 
   '@multiformats/base-x@4.0.1': {}
+
+  '@multiformats/murmur3@2.1.8':
+    dependencies:
+      multiformats: 13.1.0
+      murmurhash3js-revisited: 3.0.0
 
   '@next/env@13.4.13': {}
 
@@ -25483,6 +27920,8 @@ snapshots:
 
   '@noble/ciphers@0.5.1': {}
 
+  '@noble/ciphers@1.3.0': {}
+
   '@noble/curves@1.2.0':
     dependencies:
       '@noble/hashes': 1.3.2
@@ -25499,6 +27938,10 @@ snapshots:
     dependencies:
       '@noble/hashes': 1.5.0
 
+  '@noble/curves@1.9.7':
+    dependencies:
+      '@noble/hashes': 1.8.0
+
   '@noble/ed25519@1.7.3': {}
 
   '@noble/hashes@1.1.5': {}
@@ -25512,6 +27955,8 @@ snapshots:
   '@noble/hashes@1.4.0': {}
 
   '@noble/hashes@1.5.0': {}
+
+  '@noble/hashes@1.8.0': {}
 
   '@noble/secp256k1@1.7.1': {}
 
@@ -25723,7 +28168,7 @@ snapshots:
       chalk: 4.1.2
       enquirer: 2.3.6
       nx: 19.0.2(@swc/core@1.5.5(@swc/helpers@0.5.11))
-      tslib: 2.6.2
+      tslib: 2.8.0
       yargs-parser: 21.1.1
     transitivePeerDependencies:
       - '@swc-node/register'
@@ -25760,7 +28205,7 @@ snapshots:
   '@parcel/watcher-wasm@2.4.1':
     dependencies:
       is-glob: 4.0.3
-      micromatch: 4.0.5
+      micromatch: 4.0.8
 
   '@parcel/watcher-win32-arm64@2.4.1':
     optional: true
@@ -25775,7 +28220,7 @@ snapshots:
     dependencies:
       detect-libc: 1.0.3
       is-glob: 4.0.3
-      micromatch: 4.0.5
+      micromatch: 4.0.8
       node-addon-api: 7.1.0
     optionalDependencies:
       '@parcel/watcher-android-arm64': 2.4.1
@@ -25844,6 +28289,29 @@ snapshots:
       config-chain: 1.1.13
 
   '@polka/url@1.0.0-next.25': {}
+
+  '@protobufjs/aspromise@1.1.2': {}
+
+  '@protobufjs/base64@1.1.2': {}
+
+  '@protobufjs/codegen@2.0.4': {}
+
+  '@protobufjs/eventemitter@1.1.0': {}
+
+  '@protobufjs/fetch@1.1.0':
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/inquire': 1.1.0
+
+  '@protobufjs/float@1.0.2': {}
+
+  '@protobufjs/inquire@1.1.0': {}
+
+  '@protobufjs/path@1.1.2': {}
+
+  '@protobufjs/pool@1.1.0': {}
+
+  '@protobufjs/utf8@1.1.0': {}
 
   '@radix-ui/primitive@1.0.1':
     dependencies:
@@ -26943,7 +29411,7 @@ snapshots:
       chalk: 4.1.2
       execa: 5.1.1
       metro: 0.80.12(bufferutil@4.0.8)(utf-8-validate@6.0.3)
-      metro-config: 0.80.12(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      metro-config: 0.80.12(bufferutil@4.0.8)
       metro-core: 0.80.12
       node-fetch: 2.7.0(encoding@0.1.13)
       querystring: 0.2.1
@@ -27506,6 +29974,8 @@ snapshots:
 
   '@scure/base@1.1.9': {}
 
+  '@scure/base@2.0.0': {}
+
   '@scure/bip32@1.3.2':
     dependencies:
       '@noble/curves': 1.2.0
@@ -27521,7 +29991,7 @@ snapshots:
   '@scure/bip39@1.1.0':
     dependencies:
       '@noble/hashes': 1.1.5
-      '@scure/base': 1.1.6
+      '@scure/base': 1.1.9
 
   '@scure/bip39@1.2.1':
     dependencies:
@@ -27705,9 +30175,13 @@ snapshots:
       '@sd-jwt/decode': 0.6.1
       jwt-decode: 3.1.2
 
+  '@spruceid/siwe-parser@1.1.3':
+    dependencies:
+      apg-js: 4.4.0
+
   '@spruceid/siwe-parser@2.1.0':
     dependencies:
-      '@noble/hashes': 1.5.0
+      '@noble/hashes': 1.8.0
       apg-js: 4.4.0
       uri-js: 4.4.1
       valid-url: 1.0.9
@@ -27741,6 +30215,10 @@ snapshots:
     dependencies:
       '@stablelib/int': 1.0.1
 
+  '@stablelib/binary@2.0.1':
+    dependencies:
+      '@stablelib/int': 2.0.1
+
   '@stablelib/blockcipher@1.0.1': {}
 
   '@stablelib/bytes@1.0.1': {}
@@ -27767,7 +30245,15 @@ snapshots:
       '@stablelib/sha512': 1.0.1
       '@stablelib/wipe': 1.0.1
 
+  '@stablelib/ed25519@2.0.2':
+    dependencies:
+      '@stablelib/random': 2.0.1
+      '@stablelib/sha512': 2.0.1
+      '@stablelib/wipe': 2.0.1
+
   '@stablelib/hash@1.0.1': {}
+
+  '@stablelib/hash@2.0.0': {}
 
   '@stablelib/hkdf@1.0.1':
     dependencies:
@@ -27782,6 +30268,8 @@ snapshots:
       '@stablelib/wipe': 1.0.1
 
   '@stablelib/int@1.0.1': {}
+
+  '@stablelib/int@2.0.1': {}
 
   '@stablelib/keyagreement@1.0.1':
     dependencies:
@@ -27805,6 +30293,11 @@ snapshots:
       '@stablelib/binary': 1.0.1
       '@stablelib/wipe': 1.0.1
 
+  '@stablelib/random@2.0.1':
+    dependencies:
+      '@stablelib/binary': 2.0.1
+      '@stablelib/wipe': 2.0.1
+
   '@stablelib/salsa20@1.0.2':
     dependencies:
       '@stablelib/binary': 1.0.1
@@ -27823,7 +30316,15 @@ snapshots:
       '@stablelib/hash': 1.0.1
       '@stablelib/wipe': 1.0.1
 
+  '@stablelib/sha512@2.0.1':
+    dependencies:
+      '@stablelib/binary': 2.0.1
+      '@stablelib/hash': 2.0.0
+      '@stablelib/wipe': 2.0.1
+
   '@stablelib/wipe@1.0.1': {}
+
+  '@stablelib/wipe@2.0.1': {}
 
   '@stablelib/x25519@1.0.3':
     dependencies:
@@ -27854,7 +30355,7 @@ snapshots:
   '@stacks/common@6.5.5':
     dependencies:
       '@types/bn.js': 5.1.5
-      '@types/node': 18.19.33
+      '@types/node': 18.19.56
 
   '@stacks/encryption@6.7.0':
     dependencies:
@@ -27862,7 +30363,7 @@ snapshots:
       '@noble/secp256k1': 1.7.1
       '@scure/bip39': 1.1.0
       '@stacks/common': 6.5.5
-      '@types/node': 18.19.33
+      '@types/node': 18.19.56
       base64-js: 1.5.1
       bs58: 5.0.0
       ripemd160-min: 0.0.6
@@ -28118,7 +30619,7 @@ snapshots:
   '@swc/helpers@0.4.36':
     dependencies:
       legacy-swc-helpers: '@swc/helpers@0.4.14'
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   '@swc/helpers@0.5.11':
     dependencies:
@@ -28168,6 +30669,15 @@ snapshots:
   '@tanstack/table-core@8.16.0': {}
 
   '@tanstack/virtual-core@3.5.0': {}
+
+  '@tokenizer/inflate@0.4.1':
+    dependencies:
+      debug: 4.4.3
+      token-types: 6.1.1
+    transitivePeerDependencies:
+      - supports-color
+
+  '@tokenizer/token@0.3.0': {}
 
   '@transmute/credentials-context@0.7.0-unstable.81': {}
 
@@ -28247,7 +30757,7 @@ snapshots:
   '@transmute/jsonld-schema@0.7.0-unstable.81(web-streams-polyfill@4.0.0)':
     dependencies:
       '@transmute/jsonld': 0.0.4(web-streams-polyfill@4.0.0)
-      ajv: 8.13.0
+      ajv: 8.17.1
       genson-js: 0.0.5
     transitivePeerDependencies:
       - domexception
@@ -28317,7 +30827,7 @@ snapshots:
     dependencies:
       asn1.js: 5.4.1
       base64url: 3.0.1
-      elliptic: 6.5.5
+      elliptic: 6.6.1
 
   '@trysound/sax@0.2.0': {}
 
@@ -28372,7 +30882,7 @@ snapshots:
 
   '@types/bn.js@5.1.6':
     dependencies:
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
 
   '@types/body-parser@1.19.5':
     dependencies:
@@ -28520,6 +31030,8 @@ snapshots:
 
   '@types/lodash@4.17.1': {}
 
+  '@types/long@4.0.2': {}
+
   '@types/luxon@3.4.2': {}
 
   '@types/mdast@4.0.3':
@@ -28532,6 +31044,8 @@ snapshots:
 
   '@types/mime@1.3.5': {}
 
+  '@types/minimatch@3.0.5': {}
+
   '@types/minimist@1.2.4': {}
 
   '@types/ms@0.7.33': {}
@@ -28540,7 +31054,7 @@ snapshots:
 
   '@types/node-forge@1.3.11':
     dependencies:
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
 
   '@types/node@12.20.55': {}
 
@@ -28549,10 +31063,6 @@ snapshots:
   '@types/node@18.15.13': {}
 
   '@types/node@18.18.7':
-    dependencies:
-      undici-types: 5.26.5
-
-  '@types/node@18.19.33':
     dependencies:
       undici-types: 5.26.5
 
@@ -28567,6 +31077,10 @@ snapshots:
   '@types/node@20.12.11':
     dependencies:
       undici-types: 5.26.5
+
+  '@types/node@22.7.5':
+    dependencies:
+      undici-types: 6.19.8
 
   '@types/node@22.7.6':
     dependencies:
@@ -28751,11 +31265,11 @@ snapshots:
       - react-native
       - web-streams-polyfill
 
-  '@veramo-community/lds-ecdsa-secp256k1-recovery2020@https://codeload.github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/tar.gz/ab0db52de6f4e6663ef271a48009ba26e688ef9b(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@veramo-community/lds-ecdsa-secp256k1-recovery2020@https://codeload.github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/tar.gz/ab0db52de6f4e6663ef271a48009ba26e688ef9b(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@bitauth/libauth': 1.19.1
-      '@digitalcredentials/jsonld': 5.2.2(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
-      '@digitalcredentials/jsonld-signatures': 9.4.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+      '@digitalcredentials/jsonld': 5.2.2(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
+      '@digitalcredentials/jsonld-signatures': 9.4.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
       '@ethersproject/transactions': 5.7.0
       '@trust/keyto': 1.0.1
       base64url: 3.0.1
@@ -28771,7 +31285,7 @@ snapshots:
   '@veramo/core-types@5.6.1-next.57':
     dependencies:
       credential-status: 3.0.1
-      debug: 4.3.4
+      debug: 4.3.7
       did-jwt-vc: 4.0.0
       did-resolver: 4.1.0
     transitivePeerDependencies:
@@ -28780,7 +31294,7 @@ snapshots:
   '@veramo/core-types@5.6.1-unstable.36':
     dependencies:
       credential-status: 2.0.6
-      debug: 4.3.4
+      debug: 4.3.7
       did-jwt-vc: 4.0.0
       did-resolver: 4.1.0
     transitivePeerDependencies:
@@ -28855,17 +31369,17 @@ snapshots:
       - utf-8-validate
       - web-streams-polyfill
 
-  '@veramo/credential-ld@6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@veramo/credential-ld@6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@digitalcredentials/ed25519-signature-2020': 4.0.0(expo-crypto@13.0.2(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)))(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3))(msrcrypto@1.5.8)(react-native-securerandom@1.0.1(react-native@0.74.1(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(@types/react@18.2.14)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@6.0.3)))
       '@digitalcredentials/ed25519-verification-key-2020': 4.0.0
-      '@digitalcredentials/jsonld': 6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+      '@digitalcredentials/jsonld': 6.0.0(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
       '@digitalcredentials/jsonld-signatures': 10.0.1(expo-crypto@13.0.2(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)))(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3))(msrcrypto@1.5.8)(react-native-securerandom@1.0.1(react-native@0.74.1(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(@types/react@18.2.14)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@6.0.3)))
       '@digitalcredentials/vc': 7.0.0(expo-crypto@13.0.2(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)))(expo@51.0.2(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3))(msrcrypto@1.5.8)(react-native-securerandom@1.0.1(react-native@0.74.1(@babel/core@7.25.8)(@babel/preset-env@7.25.8(@babel/core@7.25.8))(@types/react@18.2.14)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)(utf-8-validate@6.0.3)))
       '@transmute/credentials-context': 0.7.0-unstable.81
       '@transmute/ed25519-signature-2018': 0.7.0-unstable.81(web-streams-polyfill@4.0.0)
       '@transmute/json-web-signature': 0.7.0-unstable.81(web-streams-polyfill@4.0.0)
-      '@veramo-community/lds-ecdsa-secp256k1-recovery2020': https://codeload.github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/tar.gz/ab0db52de6f4e6663ef271a48009ba26e688ef9b(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+      '@veramo-community/lds-ecdsa-secp256k1-recovery2020': https://codeload.github.com/uport-project/EcdsaSecp256k1RecoverySignature2020/tar.gz/ab0db52de6f4e6663ef271a48009ba26e688ef9b(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
       '@veramo/core-types': 6.0.0
       '@veramo/utils': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
       cross-fetch: 4.0.0(patch_hash=o37ixiuozlaw3unzpuuojolyvy)(encoding@0.1.13)
@@ -28954,7 +31468,7 @@ snapshots:
       - utf-8-validate
       - web-streams-polyfill
 
-  '@veramo/credential-w3c@6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))':
+  '@veramo/credential-w3c@6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)':
     dependencies:
       '@veramo/core-types': 6.0.0
       '@veramo/message-handler': 6.0.0
@@ -28966,7 +31480,7 @@ snapshots:
       did-resolver: 4.1.0
       uuid: 9.0.1
     optionalDependencies:
-      '@veramo/credential-ld': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))
+      '@veramo/credential-ld': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1))(web-streams-polyfill@4.0.0)
     transitivePeerDependencies:
       - bufferutil
       - domexception
@@ -29043,14 +31557,14 @@ snapshots:
   '@veramo/did-discovery@5.6.1-unstable.36':
     dependencies:
       '@veramo/core-types': 5.6.1-unstable.36
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
   '@veramo/did-discovery@6.0.0':
     dependencies:
       '@veramo/core-types': 6.0.0
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -29088,6 +31602,20 @@ snapshots:
       '@veramo/utils': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
       debug: 4.3.4
       did-resolver: 4.1.0
+    transitivePeerDependencies:
+      - bufferutil
+      - encoding
+      - supports-color
+      - utf-8-validate
+
+  '@veramo/did-provider-key@6.0.0(bufferutil@4.0.8)(encoding@0.1.13)':
+    dependencies:
+      '@veramo/core-types': 6.0.0
+      '@veramo/did-manager': 6.0.0
+      '@veramo/utils': 6.0.0(bufferutil@4.0.8)(encoding@0.1.13)(utf-8-validate@6.0.3)
+      debug: 4.4.3
+      did-resolver: 4.1.0
+      ethers: 6.11.1(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -29156,7 +31684,7 @@ snapshots:
   '@veramo/message-handler@6.0.0':
     dependencies:
       '@veramo/core-types': 6.0.0
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -29362,6 +31890,42 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
+  '@walletconnect/core@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(ioredis@5.4.1)':
+    dependencies:
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.3
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/jsonrpc-ws-connection': 1.0.13(bufferutil@4.0.8)
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/relay-api': 1.0.10
+      '@walletconnect/relay-auth': 1.0.4
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/utils': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      events: 3.3.0
+      lodash.isequal: 4.5.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+
   '@walletconnect/environment@1.0.1':
     dependencies:
       tslib: 1.14.1
@@ -29399,9 +31963,47 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
+  '@walletconnect/ethereum-provider@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(@walletconnect/modal@2.6.1(react@18.3.1))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)':
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
+      '@walletconnect/jsonrpc-provider': 1.0.14
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/sign-client': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(ioredis@5.4.1)
+      '@walletconnect/types': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/universal-provider': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)
+      '@walletconnect/utils': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      events: 3.3.0
+    optionalDependencies:
+      '@walletconnect/modal': 2.6.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+
   '@walletconnect/events@1.0.1':
     dependencies:
       keyvaluestorage-interface: 1.0.0
+      tslib: 1.14.1
+
+  '@walletconnect/heartbeat@1.2.1':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/time': 1.0.2
       tslib: 1.14.1
 
   '@walletconnect/heartbeat@1.2.2':
@@ -29419,11 +32021,22 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
+  '@walletconnect/jsonrpc-provider@1.0.13':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      tslib: 1.14.1
+
   '@walletconnect/jsonrpc-provider@1.0.14':
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       events: 3.3.0
+
+  '@walletconnect/jsonrpc-types@1.0.3':
+    dependencies:
+      keyvaluestorage-interface: 1.0.0
+      tslib: 1.14.1
 
   '@walletconnect/jsonrpc-types@1.0.4':
     dependencies:
@@ -29436,12 +32049,23 @@ snapshots:
       '@walletconnect/jsonrpc-types': 1.0.4
       tslib: 1.14.1
 
+  '@walletconnect/jsonrpc-ws-connection@1.0.13(bufferutil@4.0.8)':
+    dependencies:
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/safe-json': 1.0.2
+      events: 3.3.0
+      tslib: 1.14.1
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@walletconnect/jsonrpc-ws-connection@1.0.14(bufferutil@4.0.8)':
     dependencies:
       '@walletconnect/jsonrpc-utils': 1.0.8
       '@walletconnect/safe-json': 1.0.2
       events: 3.3.0
-      ws: 7.5.9(bufferutil@4.0.8)
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
@@ -29473,11 +32097,26 @@ snapshots:
       '@walletconnect/safe-json': 1.0.2
       pino: 7.11.0
 
+  '@walletconnect/modal-core@2.6.1(react@18.3.1)':
+    dependencies:
+      valtio: 1.11.0(react@18.3.1)
+    transitivePeerDependencies:
+      - react
+
   '@walletconnect/modal-core@2.6.2(@types/react@18.3.1)(react@18.3.1)':
     dependencies:
       valtio: 1.11.2(@types/react@18.3.1)(react@18.3.1)
     transitivePeerDependencies:
       - '@types/react'
+      - react
+
+  '@walletconnect/modal-ui@2.6.1(react@18.3.1)':
+    dependencies:
+      '@walletconnect/modal-core': 2.6.1(react@18.3.1)
+      lit: 2.7.6
+      motion: 10.16.2
+      qrcode: 1.5.3
+    transitivePeerDependencies:
       - react
 
   '@walletconnect/modal-ui@2.6.2(@types/react@18.3.1)(react@18.3.1)':
@@ -29488,6 +32127,13 @@ snapshots:
       qrcode: 1.5.3
     transitivePeerDependencies:
       - '@types/react'
+      - react
+
+  '@walletconnect/modal@2.6.1(react@18.3.1)':
+    dependencies:
+      '@walletconnect/modal-core': 2.6.1(react@18.3.1)
+      '@walletconnect/modal-ui': 2.6.1(react@18.3.1)
+    transitivePeerDependencies:
       - react
 
   '@walletconnect/modal@2.6.2(@types/react@18.3.1)(react@18.3.1)':
@@ -29545,6 +32191,35 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
+  '@walletconnect/sign-client@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(ioredis@5.4.1)':
+    dependencies:
+      '@walletconnect/core': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(ioredis@5.4.1)
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/utils': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+
   '@walletconnect/time@1.0.2':
     dependencies:
       tslib: 1.14.1
@@ -29554,6 +32229,30 @@ snapshots:
       '@walletconnect/events': 1.0.1
       '@walletconnect/heartbeat': 1.2.2
       '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/logger': 2.1.2
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+
+  '@walletconnect/types@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)':
+    dependencies:
+      '@walletconnect/events': 1.0.1
+      '@walletconnect/heartbeat': 1.2.1
+      '@walletconnect/jsonrpc-types': 1.0.3
       '@walletconnect/keyvaluestorage': 1.1.1(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
       '@walletconnect/logger': 2.1.2
       events: 3.3.0
@@ -29603,6 +32302,36 @@ snapshots:
       - uWebSockets.js
       - utf-8-validate
 
+  '@walletconnect/universal-provider@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(encoding@0.1.13)(ioredis@5.4.1)':
+    dependencies:
+      '@walletconnect/jsonrpc-http-connection': 1.0.8(encoding@0.1.13)
+      '@walletconnect/jsonrpc-provider': 1.0.13
+      '@walletconnect/jsonrpc-types': 1.0.4
+      '@walletconnect/jsonrpc-utils': 1.0.8
+      '@walletconnect/logger': 2.1.2
+      '@walletconnect/sign-client': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(bufferutil@4.0.8)(ioredis@5.4.1)
+      '@walletconnect/types': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/utils': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      events: 3.3.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - bufferutil
+      - encoding
+      - ioredis
+      - uWebSockets.js
+      - utf-8-validate
+
   '@walletconnect/utils@2.13.0(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)':
     dependencies:
       '@stablelib/chacha20poly1305': 1.0.1
@@ -29619,6 +32348,38 @@ snapshots:
       detect-browser: 5.3.0
       query-string: 7.1.3
       uint8arrays: 3.1.0
+    transitivePeerDependencies:
+      - '@azure/app-configuration'
+      - '@azure/cosmos'
+      - '@azure/data-tables'
+      - '@azure/identity'
+      - '@azure/keyvault-secrets'
+      - '@azure/storage-blob'
+      - '@capacitor/preferences'
+      - '@netlify/blobs'
+      - '@planetscale/database'
+      - '@react-native-async-storage/async-storage'
+      - '@upstash/redis'
+      - '@vercel/kv'
+      - ioredis
+      - uWebSockets.js
+
+  '@walletconnect/utils@2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)':
+    dependencies:
+      '@stablelib/chacha20poly1305': 1.0.1
+      '@stablelib/hkdf': 1.0.1
+      '@stablelib/random': 1.0.2
+      '@stablelib/sha256': 1.0.1
+      '@stablelib/x25519': 1.0.3
+      '@walletconnect/relay-api': 1.0.10
+      '@walletconnect/safe-json': 1.0.2
+      '@walletconnect/time': 1.0.2
+      '@walletconnect/types': 2.9.2(@react-native-async-storage/async-storage@1.23.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)))(ioredis@5.4.1)
+      '@walletconnect/window-getters': 1.0.1
+      '@walletconnect/window-metadata': 1.0.1
+      detect-browser: 5.3.0
+      query-string: 7.1.3
+      uint8arrays: 3.1.1
     transitivePeerDependencies:
       - '@azure/app-configuration'
       - '@azure/cosmos'
@@ -29823,19 +32584,19 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
   agent-base@7.1.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -29852,6 +32613,10 @@ snapshots:
     optionalDependencies:
       ajv: 8.13.0
 
+  ajv-formats@2.1.1(ajv@8.17.1):
+    optionalDependencies:
+      ajv: 8.17.1
+
   ajv-formats@3.0.1(ajv@8.17.1):
     optionalDependencies:
       ajv: 8.17.1
@@ -29860,9 +32625,9 @@ snapshots:
     dependencies:
       ajv: 6.12.6
 
-  ajv-keywords@5.1.0(ajv@8.13.0):
+  ajv-keywords@5.1.0(ajv@8.17.1):
     dependencies:
-      ajv: 8.13.0
+      ajv: 8.17.1
       fast-deep-equal: 3.1.3
 
   ajv@6.12.6:
@@ -29960,6 +32725,8 @@ snapshots:
 
   any-promise@1.3.0: {}
 
+  any-signal@3.0.1: {}
+
   anymatch@3.1.3:
     dependencies:
       normalize-path: 3.0.0
@@ -29985,7 +32752,7 @@ snapshots:
 
   aria-hidden@1.2.4:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -30072,7 +32839,7 @@ snapshots:
 
   async-mutex@0.2.6:
     dependencies:
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   async@3.2.5: {}
 
@@ -30096,9 +32863,15 @@ snapshots:
     dependencies:
       possible-typed-array-names: 1.0.0
 
+  axios@0.21.4(debug@4.4.3):
+    dependencies:
+      follow-redirects: 1.15.6(debug@4.4.3)
+    transitivePeerDependencies:
+      - debug
+
   axios@1.1.3:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.4.3)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -30122,7 +32895,7 @@ snapshots:
 
   axios@1.6.8:
     dependencies:
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.4.3)
       form-data: 4.0.0
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -30394,6 +33167,10 @@ snapshots:
     dependencies:
       base64url: 3.0.1
 
+  base64url-universal@2.0.0:
+    dependencies:
+      base64url: 3.0.1
+
   base64url@3.0.1: {}
 
   batch@0.6.1: {}
@@ -30446,14 +33223,31 @@ snapshots:
     dependencies:
       file-uri-to-path: 1.0.0
 
+  bip174@2.1.1: {}
+
   bip66@1.1.5:
     dependencies:
       safe-buffer: 5.2.1
     optional: true
 
+  bitcoinjs-lib@6.1.7:
+    dependencies:
+      '@noble/hashes': 1.5.0
+      bech32: 2.0.0
+      bip174: 2.1.1
+      bs58check: 3.0.1
+      typeforce: 1.18.0
+      varuint-bitcoin: 1.1.2
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
+      inherits: 2.0.4
+      readable-stream: 3.6.2
+
+  bl@5.1.0:
+    dependencies:
+      buffer: 6.0.3
       inherits: 2.0.4
       readable-stream: 3.6.2
 
@@ -30463,6 +33257,21 @@ snapshots:
       nanoassert: 2.0.0
 
   blakejs@1.2.1: {}
+
+  blob-to-it@1.0.4:
+    dependencies:
+      browser-readablestream-to-it: 1.0.3
+
+  blockstore-core@3.0.0:
+    dependencies:
+      err-code: 3.0.1
+      interface-blockstore: 4.0.1
+      interface-store: 3.0.4
+      it-all: 2.0.1
+      it-drain: 2.0.1
+      it-filter: 2.0.2
+      it-take: 2.0.1
+      multiformats: 11.0.2
 
   bluebird@3.7.2: {}
 
@@ -30561,6 +33370,8 @@ snapshots:
       safe-buffer: 5.2.1
       through2: 2.0.5
       umd: 3.0.3
+
+  browser-readablestream-to-it@1.0.3: {}
 
   browser-resolve@2.0.0:
     dependencies:
@@ -30695,6 +33506,11 @@ snapshots:
       create-hash: 1.2.0
       safe-buffer: 5.2.1
 
+  bs58check@3.0.1:
+    dependencies:
+      '@noble/hashes': 1.8.0
+      bs58: 5.0.0
+
   bser@2.1.1:
     dependencies:
       node-int64: 0.4.0
@@ -30752,7 +33568,7 @@ snapshots:
 
   c32check@2.0.0:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.8.0
       base-x: 4.0.0
 
   cac@6.7.14: {}
@@ -30833,7 +33649,7 @@ snapshots:
   camel-case@4.1.2:
     dependencies:
       pascal-case: 3.1.2
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   camelcase-css@2.0.1: {}
 
@@ -31384,6 +34200,13 @@ snapshots:
     optionalDependencies:
       typescript: 5.4.5
 
+  cosmjs-types@0.10.1: {}
+
+  cosmjs-types@0.7.2:
+    dependencies:
+      long: 4.0.0
+      protobufjs: 6.11.4
+
   crc-32@1.2.2: {}
 
   create-ecdh@4.0.4:
@@ -31417,7 +34240,7 @@ snapshots:
 
   credential-status@3.0.1:
     dependencies:
-      did-jwt: 8.0.1
+      did-jwt: 8.0.4(patch_hash=jwbfqko2nle36olg3vrp3gx3nm)
       did-resolver: 4.1.0
 
   credentials-context@2.0.0: {}
@@ -31429,6 +34252,10 @@ snapshots:
   cross-env@7.0.3:
     dependencies:
       cross-spawn: 7.0.3
+
+  cross-fetch@3.1.4:
+    dependencies:
+      node-fetch: 2.6.1
 
   cross-fetch@3.1.8(patch_hash=o7exbxzvysudd5km3yp6v3mgsi)(encoding@0.1.13):
     dependencies:
@@ -31648,6 +34475,11 @@ snapshots:
       '@ipld/dag-cbor': 7.0.3
       multiformats: 11.0.2
 
+  dag-jose@1.0.0:
+    dependencies:
+      '@ipld/dag-cbor': 6.0.15
+      multiformats: 9.9.0
+
   dag-map@1.0.2: {}
 
   dargs@8.1.0: {}
@@ -31685,6 +34517,8 @@ snapshots:
 
   dataloader@2.2.2: {}
 
+  date-and-time@2.4.3: {}
+
   date-fns@2.30.0:
     dependencies:
       '@babel/runtime': 7.24.5
@@ -31710,6 +34544,10 @@ snapshots:
       ms: 2.1.2
 
   debug@4.3.7:
+    dependencies:
+      ms: 2.1.3
+
+  debug@4.4.3:
     dependencies:
       ms: 2.1.3
 
@@ -31847,7 +34685,7 @@ snapshots:
   detect-port@1.6.1:
     dependencies:
       address: 1.2.2
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -31900,9 +34738,9 @@ snapshots:
   did-jwt@7.4.7:
     dependencies:
       '@noble/ciphers': 0.4.0
-      '@noble/curves': 1.4.0
-      '@noble/hashes': 1.4.0
-      '@scure/base': 1.1.6
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/base': 1.1.9
       canonicalize: 2.0.0
       did-resolver: 4.1.0
       multibase: 4.0.6
@@ -31915,6 +34753,18 @@ snapshots:
       '@noble/curves': 1.3.0
       '@noble/hashes': 1.3.3
       '@scure/base': 1.1.5
+      canonicalize: 2.0.0
+      did-resolver: 4.1.0
+      multibase: 4.0.6
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+
+  did-jwt@8.0.18:
+    dependencies:
+      '@noble/ciphers': 1.3.0
+      '@noble/curves': 1.6.0
+      '@noble/hashes': 1.5.0
+      '@scure/base': 2.0.0
       canonicalize: 2.0.0
       did-resolver: 4.1.0
       multibase: 4.0.6
@@ -31978,6 +34828,15 @@ snapshots:
 
   dlv@1.1.3: {}
 
+  dns-over-http-resolver@1.2.3(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      debug: 4.4.3
+      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      receptacle: 1.3.2
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
   dns-packet@5.6.1:
     dependencies:
       '@leichtgewicht/ip-codec': 2.0.5
@@ -32031,7 +34890,7 @@ snapshots:
   dot-case@3.0.4:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   dot-prop@5.3.0:
     dependencies:
@@ -32120,6 +34979,10 @@ snapshots:
     dependencies:
       jake: 10.9.1
 
+  electron-fetch@1.9.1:
+    dependencies:
+      encoding: 0.1.13
+
   electron-to-chromium@1.4.540: {}
 
   electron-to-chromium@1.4.762: {}
@@ -32137,6 +35000,16 @@ snapshots:
       minimalistic-crypto-utils: 1.0.1
 
   elliptic@6.5.5:
+    dependencies:
+      bn.js: 4.12.0
+      brorand: 1.1.0
+      hash.js: 1.1.7
+      hmac-drbg: 1.0.1
+      inherits: 2.0.4
+      minimalistic-assert: 1.0.1
+      minimalistic-crypto-utils: 1.0.1
+
+  elliptic@6.6.1:
     dependencies:
       bn.js: 4.12.0
       brorand: 1.1.0
@@ -32177,7 +35050,7 @@ snapshots:
   engine.io-client@6.5.3(bufferutil@4.0.8):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4
+      debug: 4.3.7
       engine.io-parser: 5.2.2
       ws: 8.11.0(bufferutil@4.0.8)
       xmlhttprequest-ssl: 2.0.0
@@ -32655,6 +35528,19 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
+  ethers@6.16.0(bufferutil@4.0.8):
+    dependencies:
+      '@adraffy/ens-normalize': 1.10.1
+      '@noble/curves': 1.2.0
+      '@noble/hashes': 1.3.2
+      '@types/node': 22.7.5
+      aes-js: 4.0.0-beta.5
+      tslib: 2.7.0
+      ws: 8.17.1(bufferutil@4.0.8)
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   ethers@6.8.0(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     dependencies:
       '@adraffy/ens-normalize': 1.10.0
@@ -32878,7 +35764,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  exponential-backoff@3.1.1: {}
+  exponential-backoff@3.1.3: {}
 
   express@4.19.2:
     dependencies:
@@ -32926,7 +35812,7 @@ snapshots:
 
   extension-port-stream@3.0.0:
     dependencies:
-      readable-stream: 4.5.2
+      readable-stream: 4.7.0
       webextension-polyfill: 0.10.0
 
   extension-port-stream@4.2.0(webextension-polyfill@0.10.0):
@@ -32946,6 +35832,8 @@ snapshots:
       source-map-support: 0.5.21
 
   fast-deep-equal@3.1.3: {}
+
+  fast-fifo@1.3.2: {}
 
   fast-glob@3.2.7:
     dependencies:
@@ -33070,6 +35958,21 @@ snapshots:
 
   file-saver@2.0.5: {}
 
+  file-type@16.5.4:
+    dependencies:
+      readable-web-to-node-stream: 3.0.4
+      strtok3: 6.3.0
+      token-types: 4.2.1
+
+  file-type@21.1.1:
+    dependencies:
+      '@tokenizer/inflate': 0.4.1
+      strtok3: 10.3.4
+      token-types: 6.1.1
+      uint8array-extras: 1.5.0
+    transitivePeerDependencies:
+      - supports-color
+
   file-uri-to-path@1.0.0: {}
 
   filelist@1.0.4:
@@ -33177,7 +36080,9 @@ snapshots:
 
   follow-redirects@1.15.3: {}
 
-  follow-redirects@1.15.6: {}
+  follow-redirects@1.15.6(debug@4.4.3):
+    optionalDependencies:
+      debug: 4.4.3
 
   fontfaceobserver@2.3.0: {}
 
@@ -33354,6 +36259,8 @@ snapshots:
       - encoding
       - supports-color
 
+  generate-password@1.7.1: {}
+
   genson-js@0.0.5: {}
 
   gensync@1.0.0-beta.2: {}
@@ -33385,6 +36292,8 @@ snapshots:
       has-symbols: 1.1.0
       hasown: 2.0.2
       math-intrinsics: 1.1.0
+
+  get-iterator@1.0.2: {}
 
   get-nonce@1.0.1: {}
 
@@ -33616,6 +36525,11 @@ snapshots:
     transitivePeerDependencies:
       - uWebSockets.js
 
+  hamt-sharding@3.0.6:
+    dependencies:
+      sparse-array: 1.3.2
+      uint8arrays: 5.1.0
+
   handle-thing@2.0.1: {}
 
   hard-rejection@2.1.0: {}
@@ -33661,6 +36575,8 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       safe-buffer: 5.2.1
+
+  hash-wasm@4.12.0: {}
 
   hash.js@1.1.7:
     dependencies:
@@ -33923,7 +36839,7 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -33942,7 +36858,7 @@ snapshots:
   http-proxy@1.18.1:
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.6
+      follow-redirects: 1.15.6(debug@4.4.3)
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -33959,14 +36875,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.3.7
+      debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.0
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -34028,6 +36944,8 @@ snapshots:
   image-size@1.1.1:
     dependencies:
       queue: 6.0.2
+
+  immediate@3.0.6: {}
 
   immer@10.1.1:
     optional: true
@@ -34115,6 +37033,21 @@ snapshots:
       undeclared-identifiers: 1.1.3
       xtend: 4.0.2
 
+  interface-blockstore@4.0.1:
+    dependencies:
+      interface-store: 3.0.4
+      multiformats: 11.0.2
+
+  interface-datastore@6.1.1:
+    dependencies:
+      interface-store: 2.0.2
+      nanoid: 3.3.7
+      uint8arrays: 3.1.1
+
+  interface-store@2.0.2: {}
+
+  interface-store@3.0.4: {}
+
   internal-ip@4.3.0:
     dependencies:
       default-gateway: 4.2.0
@@ -34135,7 +37068,7 @@ snapshots:
       '@formatjs/ecma402-abstract': 1.18.2
       '@formatjs/fast-memoize': 2.2.0
       '@formatjs/icu-messageformat-parser': 2.7.6
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   intl@1.2.5(patch_hash=2i3sho75ida2jvn4xlmbxxe25i): {}
 
@@ -34147,7 +37080,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.2
-      debug: 4.3.7
+      debug: 4.4.3
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -34160,15 +37093,132 @@ snapshots:
 
   ip-regex@2.1.0: {}
 
+  ip-regex@4.3.0: {}
+
   ipaddr.js@1.9.1: {}
 
   ipaddr.js@2.2.0: {}
+
+  ipfs-core-types@0.10.3(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      '@ipld/dag-pb': 2.1.18
+      interface-datastore: 6.1.1
+      ipfs-unixfs: 6.0.9
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
+  ipfs-core-utils@0.14.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      any-signal: 3.0.1
+      blob-to-it: 1.0.4
+      browser-readablestream-to-it: 1.0.3
+      debug: 4.4.3
+      err-code: 3.0.1
+      ipfs-core-types: 0.10.3(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-unixfs: 6.0.9
+      ipfs-utils: 9.0.14(encoding@0.1.13)
+      it-all: 1.0.6
+      it-map: 1.0.6
+      it-peekable: 1.0.3
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiaddr-to-uri: 8.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+      nanoid: 3.3.7
+      parse-duration: 1.1.2
+      timeout-abort-controller: 3.0.0
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - node-fetch
+      - supports-color
+
+  ipfs-http-client@56.0.0(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      '@ipld/dag-cbor': 7.0.3
+      '@ipld/dag-json': 8.0.11
+      '@ipld/dag-pb': 2.1.18
+      any-signal: 3.0.1
+      dag-jose: 1.0.0
+      debug: 4.4.3
+      err-code: 3.0.1
+      ipfs-core-types: 0.10.3(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-core-utils: 0.14.3(encoding@0.1.13)(node-fetch@2.7.0(encoding@0.1.13))
+      ipfs-utils: 9.0.14(encoding@0.1.13)
+      it-first: 1.0.7
+      it-last: 1.0.6
+      merge-options: 3.0.4
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+      multiformats: 9.9.0
+      parse-duration: 1.1.2
+      stream-to-it: 0.2.4
+      uint8arrays: 3.1.1
+    transitivePeerDependencies:
+      - encoding
+      - node-fetch
+      - supports-color
+
+  ipfs-unixfs-importer@12.0.1(encoding@0.1.13):
+    dependencies:
+      '@ipld/dag-pb': 4.0.8
+      '@multiformats/murmur3': 2.1.8
+      err-code: 3.0.1
+      hamt-sharding: 3.0.6
+      interface-blockstore: 4.0.1
+      ipfs-unixfs: 9.0.1
+      it-all: 2.0.1
+      it-batch: 2.0.1
+      it-first: 2.0.1
+      it-parallel-batch: 2.0.1
+      merge-options: 3.0.4
+      multiformats: 11.0.2
+      rabin-wasm: 0.1.5(encoding@0.1.13)
+      uint8arraylist: 2.4.8
+      uint8arrays: 4.0.6
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   ipfs-unixfs@11.1.2:
     dependencies:
       err-code: 3.0.1
       protons-runtime: 5.2.2
       uint8arraylist: 2.4.8
+
+  ipfs-unixfs@6.0.9:
+    dependencies:
+      err-code: 3.0.1
+      protobufjs: 6.11.4
+
+  ipfs-unixfs@9.0.1:
+    dependencies:
+      err-code: 3.0.1
+      protobufjs: 7.5.4
+
+  ipfs-utils@9.0.14(encoding@0.1.13):
+    dependencies:
+      any-signal: 3.0.1
+      browser-readablestream-to-it: 1.0.3
+      buffer: 6.0.3
+      electron-fetch: 1.9.1
+      err-code: 3.0.1
+      is-electron: 2.2.2
+      iso-url: 1.2.1
+      it-all: 1.0.6
+      it-glob: 1.0.2
+      it-to-stream: 1.0.0
+      merge-options: 3.0.4
+      nanoid: 3.3.7
+      native-fetch: 3.0.0(node-fetch@2.7.0(encoding@0.1.13))
+      node-fetch: 2.7.0(encoding@0.1.13)
+      react-native-fetch-api: 3.0.0
+      stream-to-it: 0.2.4
+    transitivePeerDependencies:
+      - encoding
 
   iron-webcrypto@1.2.1: {}
 
@@ -34246,6 +37296,8 @@ snapshots:
 
   is-docker@3.0.0: {}
 
+  is-electron@2.2.2: {}
+
   is-extendable@0.1.1: {}
 
   is-extglob@1.0.0: {}
@@ -34299,6 +37351,10 @@ snapshots:
     dependencies:
       is-glob: 2.0.1
 
+  is-ip@3.1.0:
+    dependencies:
+      ip-regex: 4.3.0
+
   is-map@2.0.3: {}
 
   is-nan@1.3.2:
@@ -34325,8 +37381,7 @@ snapshots:
 
   is-plain-obj@1.1.0: {}
 
-  is-plain-obj@2.1.0:
-    optional: true
+  is-plain-obj@2.1.0: {}
 
   is-plain-obj@3.0.0: {}
 
@@ -34441,6 +37496,8 @@ snapshots:
 
   isexe@2.0.0: {}
 
+  iso-url@1.2.1: {}
+
   isobject@3.0.1: {}
 
   isomorphic-timers-promises@1.0.1: {}
@@ -34489,7 +37546,11 @@ snapshots:
       - react-native
     optional: true
 
-  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)):
+  isomorphic-ws@4.0.1(ws@7.5.10(bufferutil@4.0.8)):
+    dependencies:
+      ws: 7.5.10(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+
+  isows@1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)):
     dependencies:
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
 
@@ -34523,7 +37584,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.1:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -34532,7 +37593,7 @@ snapshots:
   istanbul-lib-source-maps@5.0.4:
     dependencies:
       '@jridgewell/trace-mapping': 0.3.25
-      debug: 4.3.4
+      debug: 4.3.7
       istanbul-lib-coverage: 3.2.2
     transitivePeerDependencies:
       - supports-color
@@ -34542,7 +37603,45 @@ snapshots:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
 
+  it-all@1.0.6: {}
+
+  it-all@2.0.1: {}
+
+  it-batch@2.0.1: {}
+
+  it-drain@2.0.1: {}
+
+  it-filter@2.0.2: {}
+
   it-first@1.0.7: {}
+
+  it-first@2.0.1: {}
+
+  it-glob@1.0.2:
+    dependencies:
+      '@types/minimatch': 3.0.5
+      minimatch: 3.1.2
+
+  it-last@1.0.6: {}
+
+  it-map@1.0.6: {}
+
+  it-parallel-batch@2.0.1:
+    dependencies:
+      it-batch: 2.0.1
+
+  it-peekable@1.0.3: {}
+
+  it-take@2.0.1: {}
+
+  it-to-stream@1.0.0:
+    dependencies:
+      buffer: 6.0.3
+      fast-fifo: 1.3.2
+      get-iterator: 1.0.2
+      p-defer: 3.0.0
+      p-fifo: 1.0.0
+      readable-stream: 3.6.2
 
   jackspeak@2.3.6:
     dependencies:
@@ -34644,7 +37743,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       jest-mock: 29.7.0
       jest-util: 29.7.0
 
@@ -34698,7 +37797,7 @@ snapshots:
   jest-mock@29.7.0:
     dependencies:
       '@jest/types': 29.6.3
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       jest-util: 29.7.0
 
   jest-pnp-resolver@1.2.3(jest-resolve@29.7.0):
@@ -34834,7 +37933,7 @@ snapshots:
 
   jest-worker@29.7.0:
     dependencies:
-      '@types/node': 22.7.6
+      '@types/node': 20.12.11
       jest-util: 29.7.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
@@ -35049,6 +38148,15 @@ snapshots:
       - encoding
       - web-streams-polyfill
 
+  jsonld-signatures@11.5.0(web-streams-polyfill@4.0.0):
+    dependencies:
+      '@digitalbazaar/security-context': 1.0.1
+      jsonld: 8.3.3(web-streams-polyfill@4.0.0)
+      rdf-canonize: 4.0.1
+      serialize-error: 8.1.0
+    transitivePeerDependencies:
+      - web-streams-polyfill
+
   jsonld@5.2.0(web-streams-polyfill@4.0.0):
     dependencies:
       '@digitalbazaar/http-client': 1.2.0(patch_hash=yl3b524jp4dtc7mdahww7krgi4)(web-streams-polyfill@4.0.0)
@@ -35060,6 +38168,15 @@ snapshots:
       - web-streams-polyfill
 
   jsonld@8.3.1(web-streams-polyfill@4.0.0):
+    dependencies:
+      '@digitalbazaar/http-client': 3.4.1(web-streams-polyfill@4.0.0)
+      canonicalize: 1.0.8
+      lru-cache: 6.0.0
+      rdf-canonize: 3.4.0
+    transitivePeerDependencies:
+      - web-streams-polyfill
+
+  jsonld@8.3.3(web-streams-polyfill@4.0.0):
     dependencies:
       '@digitalbazaar/http-client': 3.4.1(web-streams-polyfill@4.0.0)
       canonicalize: 1.0.8
@@ -35091,7 +38208,7 @@ snapshots:
 
   jsontokens@4.0.1:
     dependencies:
-      '@noble/hashes': 1.4.0
+      '@noble/hashes': 1.8.0
       '@noble/secp256k1': 1.7.1
       base64-js: 1.5.1
 
@@ -35107,6 +38224,13 @@ snapshots:
       lodash.once: 4.1.1
       ms: 2.1.3
       semver: 7.5.4
+
+  jszip@3.10.1:
+    dependencies:
+      lie: 3.3.0
+      pako: 1.0.11
+      readable-stream: 2.3.8
+      setimmediate: 1.0.5
 
   jwa@1.4.1:
     dependencies:
@@ -35135,7 +38259,7 @@ snapshots:
   keccak@3.0.3:
     dependencies:
       node-addon-api: 2.0.2
-      node-gyp-build: 4.6.1
+      node-gyp-build: 4.8.1
       readable-stream: 3.6.2
 
   keccak@3.0.4:
@@ -35225,6 +38349,16 @@ snapshots:
     dependencies:
       prelude-ls: 1.1.2
       type-check: 0.3.2
+
+  libsodium-wrappers@0.7.15:
+    dependencies:
+      libsodium: 0.7.15
+
+  libsodium@0.7.15: {}
+
+  lie@3.3.0:
+    dependencies:
+      immediate: 3.0.6
 
   lighthouse-logger@1.4.2:
     dependencies:
@@ -35341,6 +38475,22 @@ snapshots:
   lit-html@2.8.0:
     dependencies:
       '@types/trusted-types': 2.0.7
+
+  lit-siwe@1.1.8(@ethersproject/contracts@5.7.0)(@ethersproject/hash@5.7.0)(@ethersproject/providers@5.7.2(bufferutil@4.0.8))(@ethersproject/wallet@5.7.0):
+    dependencies:
+      '@ethersproject/contracts': 5.7.0
+      '@ethersproject/hash': 5.7.0
+      '@ethersproject/providers': 5.7.2(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      '@ethersproject/wallet': 5.7.0
+      '@spruceid/siwe-parser': 1.1.3
+      '@stablelib/random': 1.0.2
+      apg-js: 4.4.0
+
+  lit@2.7.6:
+    dependencies:
+      '@lit/reactive-element': 1.6.3
+      lit-element: 3.3.3
+      lit-html: 2.8.0
 
   lit@2.8.0:
     dependencies:
@@ -35478,6 +38628,10 @@ snapshots:
       yargs: 15.4.1
 
   logplease@1.2.15: {}
+
+  long@4.0.0: {}
+
+  long@5.3.2: {}
 
   longest-streak@3.1.0: {}
 
@@ -35818,7 +38972,6 @@ snapshots:
   merge-options@3.0.4:
     dependencies:
       is-plain-obj: 2.1.0
-    optional: true
 
   merge-stream@2.0.0: {}
 
@@ -35841,7 +38994,7 @@ snapshots:
 
   metro-cache@0.80.12:
     dependencies:
-      exponential-backoff: 3.1.1
+      exponential-backoff: 3.1.3
       flow-enums-runtime: 0.0.6
       metro-core: 0.80.12
 
@@ -35852,21 +39005,6 @@ snapshots:
       flow-enums-runtime: 0.0.6
       jest-validate: 29.7.0
       metro: 0.80.12(bufferutil@4.0.8)
-      metro-cache: 0.80.12
-      metro-core: 0.80.12
-      metro-runtime: 0.80.12
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  metro-config@0.80.12(bufferutil@4.0.8)(utf-8-validate@6.0.3):
-    dependencies:
-      connect: 3.7.0
-      cosmiconfig: 5.2.1
-      flow-enums-runtime: 0.0.6
-      jest-validate: 29.7.0
-      metro: 0.80.12(bufferutil@4.0.8)(utf-8-validate@6.0.3)
       metro-cache: 0.80.12
       metro-core: 0.80.12
       metro-runtime: 0.80.12
@@ -36066,7 +39204,7 @@ snapshots:
       metro-babel-transformer: 0.80.12
       metro-cache: 0.80.12
       metro-cache-key: 0.80.12
-      metro-config: 0.80.12(bufferutil@4.0.8)(utf-8-validate@6.0.3)
+      metro-config: 0.80.12(bufferutil@4.0.8)
       metro-core: 0.80.12
       metro-file-map: 0.80.12
       metro-resolver: 0.80.12
@@ -36366,7 +39504,7 @@ snapshots:
   micromark@4.0.0:
     dependencies:
       '@types/debug': 4.1.12
-      debug: 4.3.4
+      debug: 4.4.3
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.1
@@ -36572,6 +39710,25 @@ snapshots:
 
   msrcrypto@1.5.8: {}
 
+  multiaddr-to-uri@8.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      multiaddr: 10.0.1(node-fetch@2.7.0(encoding@0.1.13))
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
+  multiaddr@10.0.1(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      dns-over-http-resolver: 1.2.3(node-fetch@2.7.0(encoding@0.1.13))
+      err-code: 3.0.1
+      is-ip: 3.1.0
+      multiformats: 9.9.0
+      uint8arrays: 3.1.1
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - node-fetch
+      - supports-color
+
   multibase@4.0.6:
     dependencies:
       '@multiformats/base-x': 4.0.1
@@ -36587,7 +39744,11 @@ snapshots:
 
   multiformats@13.1.0: {}
 
+  multiformats@13.4.2: {}
+
   multiformats@9.9.0: {}
+
+  murmurhash3js-revisited@3.0.0: {}
 
   mute-stream@0.0.8: {}
 
@@ -36600,7 +39761,7 @@ snapshots:
   n3@1.17.1:
     dependencies:
       queue-microtask: 1.2.3
-      readable-stream: 4.5.2
+      readable-stream: 4.7.0
 
   nan@2.14.0: {}
 
@@ -36609,6 +39770,10 @@ snapshots:
   nanoid@3.3.7: {}
 
   napi-build-utils@1.0.2: {}
+
+  native-fetch@3.0.0(node-fetch@2.7.0(encoding@0.1.13)):
+    dependencies:
+      node-fetch: 2.7.0(encoding@0.1.13)
 
   natural-compare@1.4.0: {}
 
@@ -36674,7 +39839,7 @@ snapshots:
   no-case@3.0.4:
     dependencies:
       lower-case: 2.0.2
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   nocache@3.0.4: {}
 
@@ -36705,6 +39870,8 @@ snapshots:
 
   node-fetch-native@1.6.4: {}
 
+  node-fetch@2.6.1: {}
+
   node-fetch@2.7.0(encoding@0.1.13):
     dependencies:
       whatwg-url: 5.0.0
@@ -36727,8 +39894,6 @@ snapshots:
   node-forge@1.3.1: {}
 
   node-gyp-build@4.6.0: {}
-
-  node-gyp-build@4.6.1: {}
 
   node-gyp-build@4.8.1: {}
 
@@ -37054,6 +40219,13 @@ snapshots:
 
   p-defer@1.0.0: {}
 
+  p-defer@3.0.0: {}
+
+  p-fifo@1.0.0:
+    dependencies:
+      fast-fifo: 1.3.2
+      p-defer: 3.0.0
+
   p-filter@2.1.0:
     dependencies:
       p-map: 2.1.0
@@ -37125,7 +40297,7 @@ snapshots:
   param-case@3.0.4:
     dependencies:
       dot-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   parent-module@1.0.1:
     dependencies:
@@ -37147,6 +40319,8 @@ snapshots:
     dependencies:
       color-name: 1.1.4
       hex-rgb: 4.3.0
+
+  parse-duration@1.1.2: {}
 
   parse-entities@4.0.1:
     dependencies:
@@ -37201,7 +40375,7 @@ snapshots:
   pascal-case@3.1.2:
     dependencies:
       no-case: 3.0.4
-      tslib: 2.6.2
+      tslib: 2.8.0
 
   password-prompt@1.1.3:
     dependencies:
@@ -37263,6 +40437,8 @@ snapshots:
       ripemd160: 2.0.2
       safe-buffer: 5.2.1
       sha.js: 2.4.11
+
+  peek-readable@4.1.0: {}
 
   periscopic@3.1.0:
     dependencies:
@@ -37720,10 +40896,41 @@ snapshots:
 
   proto-list@1.2.4: {}
 
+  protobufjs@6.11.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/long': 4.0.2
+      '@types/node': 20.12.11
+      long: 4.0.0
+
+  protobufjs@7.5.4:
+    dependencies:
+      '@protobufjs/aspromise': 1.1.2
+      '@protobufjs/base64': 1.1.2
+      '@protobufjs/codegen': 2.0.4
+      '@protobufjs/eventemitter': 1.1.0
+      '@protobufjs/fetch': 1.1.0
+      '@protobufjs/float': 1.0.2
+      '@protobufjs/inquire': 1.1.0
+      '@protobufjs/path': 1.1.2
+      '@protobufjs/pool': 1.1.0
+      '@protobufjs/utf8': 1.1.0
+      '@types/node': 20.12.11
+      long: 5.3.2
+
   protons-runtime@5.2.2:
     dependencies:
       uint8arraylist: 2.4.8
-      uint8arrays: 5.0.1
+      uint8arrays: 5.1.0
 
   proxy-addr@2.0.7:
     dependencies:
@@ -37847,6 +41054,18 @@ snapshots:
       '@iden3/binfileutils': 0.0.12
       fastfile: 0.0.20
       ffjavascript: 0.3.0
+
+  rabin-wasm@0.1.5(encoding@0.1.13):
+    dependencies:
+      '@assemblyscript/loader': 0.9.4
+      bl: 5.1.0
+      debug: 4.4.3
+      minimist: 1.2.8
+      node-fetch: 2.7.0(encoding@0.1.13)
+      readable-stream: 3.6.2
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
 
   radix3@1.1.2: {}
 
@@ -37985,6 +41204,10 @@ snapshots:
       react-loadable: '@docusaurus/react-loadable@6.0.0(react@18.3.1)'
       webpack: 5.91.0(@swc/core@1.5.5(@swc/helpers@0.5.11))
 
+  react-native-fetch-api@3.0.0:
+    dependencies:
+      p-defer: 3.0.0
+
   react-native-securerandom@0.1.1(react-native@0.74.1(@babel/core@7.23.2)(@babel/preset-env@7.25.8(@babel/core@7.23.2))(@types/react@18.3.1)(bufferutil@4.0.8)(encoding@0.1.13)(react@18.3.1)):
     dependencies:
       base64-js: 1.5.1
@@ -38115,7 +41338,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.1)(react@18.3.1)
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
@@ -38123,7 +41346,7 @@ snapshots:
     dependencies:
       react: 18.3.1
       react-style-singleton: 2.2.1(@types/react@18.3.1)(react@18.3.1)
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
@@ -38132,7 +41355,7 @@ snapshots:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.4(@types/react@18.3.1)(react@18.3.1)
       react-style-singleton: 2.2.1(@types/react@18.3.1)(react@18.3.1)
-      tslib: 2.6.2
+      tslib: 2.8.0
       use-callback-ref: 1.3.0(@types/react@18.3.1)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.1)(react@18.3.1)
     optionalDependencies:
@@ -38143,7 +41366,7 @@ snapshots:
       react: 18.3.1
       react-remove-scroll-bar: 2.3.6(@types/react@18.3.1)(react@18.3.1)
       react-style-singleton: 2.2.1(@types/react@18.3.1)(react@18.3.1)
-      tslib: 2.6.2
+      tslib: 2.8.0
       use-callback-ref: 1.3.2(@types/react@18.3.1)(react@18.3.1)
       use-sidecar: 1.1.2(@types/react@18.3.1)(react@18.3.1)
     optionalDependencies:
@@ -38198,7 +41421,7 @@ snapshots:
       get-nonce: 1.0.1
       invariant: 2.2.4
       react: 18.3.1
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
@@ -38269,6 +41492,18 @@ snapshots:
       process: 0.11.10
       string_decoder: 1.3.0
 
+  readable-stream@4.7.0:
+    dependencies:
+      abort-controller: 3.0.0
+      buffer: 6.0.3
+      events: 3.3.0
+      process: 0.11.10
+      string_decoder: 1.3.0
+
+  readable-web-to-node-stream@3.0.4:
+    dependencies:
+      readable-stream: 4.7.0
+
   readdirp@3.6.0:
     dependencies:
       picomatch: 2.3.1
@@ -38276,6 +41511,8 @@ snapshots:
   reading-time@1.5.0: {}
 
   readline@1.3.0: {}
+
+  readonly-date@1.0.0: {}
 
   real-require@0.1.0: {}
 
@@ -38285,6 +41522,10 @@ snapshots:
       esprima: 4.0.1
       source-map: 0.6.1
       tslib: 2.8.0
+
+  receptacle@1.3.2:
+    dependencies:
+      ms: 2.1.3
 
   rechoir@0.6.2:
     dependencies:
@@ -38547,6 +41788,8 @@ snapshots:
 
   ret@0.2.2: {}
 
+  retimer@3.0.0: {}
+
   retry@0.13.1: {}
 
   reusify@1.0.4: {}
@@ -38723,9 +41966,9 @@ snapshots:
   schema-utils@4.2.0:
     dependencies:
       '@types/json-schema': 7.0.15
-      ajv: 8.13.0
-      ajv-formats: 2.1.1(ajv@8.13.0)
-      ajv-keywords: 5.1.0(ajv@8.13.0)
+      ajv: 8.17.1
+      ajv-formats: 2.1.1(ajv@8.17.1)
+      ajv-keywords: 5.1.0(ajv@8.17.1)
 
   scroll-into-view-if-needed@3.0.10:
     dependencies:
@@ -38742,22 +41985,28 @@ snapshots:
       bn.js: 4.12.0
       create-hash: 1.2.0
       drbg.js: 1.0.1
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       nan: 2.14.0
       safe-buffer: 5.2.1
     optional: true
 
   secp256k1@4.0.3:
     dependencies:
-      elliptic: 6.5.5
+      elliptic: 6.6.1
       node-addon-api: 2.0.2
-      node-gyp-build: 4.6.1
+      node-gyp-build: 4.8.1
 
   secp256k1@5.0.0:
     dependencies:
       elliptic: 6.5.5
       node-addon-api: 5.1.0
       node-gyp-build: 4.6.0
+
+  secp256k1@5.0.1:
+    dependencies:
+      elliptic: 6.6.1
+      node-addon-api: 5.1.0
+      node-gyp-build: 4.8.1
 
   section-matter@1.0.0:
     dependencies:
@@ -39052,6 +42301,21 @@ snapshots:
       arg: 5.0.2
       sax: 1.3.0
 
+  siwe-recap@0.0.2-alpha.0(ethers@5.7.2(bufferutil@4.0.8)):
+    dependencies:
+      canonicalize: 2.0.0
+      ethers: 5.7.2(bufferutil@4.0.8)
+      multiformats: 11.0.2
+      siwe: 2.3.2(ethers@5.7.2(bufferutil@4.0.8))
+
+  siwe@2.3.2(ethers@5.7.2(bufferutil@4.0.8)):
+    dependencies:
+      '@spruceid/siwe-parser': 2.1.2
+      '@stablelib/random': 1.0.2
+      ethers: 5.7.2(bufferutil@4.0.8)
+      uri-js: 4.4.1
+      valid-url: 1.0.9
+
   siwe@2.3.2(ethers@6.11.1(bufferutil@4.0.8)):
     dependencies:
       '@spruceid/siwe-parser': 2.1.2
@@ -39116,7 +42380,7 @@ snapshots:
   socket.io-client@4.7.5(bufferutil@4.0.8):
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4
+      debug: 4.3.7
       engine.io-client: 6.5.3(bufferutil@4.0.8)
       socket.io-parser: 4.2.4
     transitivePeerDependencies:
@@ -39127,7 +42391,7 @@ snapshots:
   socket.io-parser@4.2.4:
     dependencies:
       '@socket.io/component-emitter': 3.1.2
-      debug: 4.3.4
+      debug: 4.3.7
     transitivePeerDependencies:
       - supports-color
 
@@ -39176,6 +42440,8 @@ snapshots:
 
   space-separated-tokens@2.0.2: {}
 
+  sparse-array@1.3.2: {}
+
   spawn-command@0.0.2: {}
 
   spawndamnit@2.0.0:
@@ -39199,7 +42465,7 @@ snapshots:
 
   spdy-transport@3.0.0:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       detect-node: 2.1.0
       hpack.js: 2.1.6
       obuf: 1.1.2
@@ -39210,7 +42476,7 @@ snapshots:
 
   spdy@4.0.2:
     dependencies:
-      debug: 4.3.4
+      debug: 4.3.7
       handle-thing: 2.0.1
       http-deceiver: 1.2.7
       select-hose: 2.0.0
@@ -39290,6 +42556,10 @@ snapshots:
     dependencies:
       inherits: 2.0.4
       readable-stream: 2.3.8
+
+  stream-to-it@0.2.4:
+    dependencies:
+      get-iterator: 1.0.2
 
   stream-transform@2.1.3:
     dependencies:
@@ -39434,6 +42704,15 @@ snapshots:
       minimist: 1.2.8
       through: 2.3.8
 
+  strtok3@10.3.4:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+
+  strtok3@6.3.0:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      peek-readable: 4.1.0
+
   structured-headers@0.4.1: {}
 
   style-to-object@0.4.4:
@@ -39554,6 +42833,8 @@ snapshots:
       client-only: 0.0.1
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
+
+  symbol-observable@2.0.3: {}
 
   symbol-tree@3.2.4: {}
 
@@ -39765,6 +43046,10 @@ snapshots:
 
   thunky@1.1.0: {}
 
+  timeout-abort-controller@3.0.0:
+    dependencies:
+      retimer: 3.0.0
+
   timers-browserify@1.4.2:
     dependencies:
       process: 0.11.10
@@ -39800,6 +43085,17 @@ snapshots:
       is-number: 7.0.0
 
   toidentifier@1.0.1: {}
+
+  token-types@4.2.1:
+    dependencies:
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
+
+  token-types@6.1.1:
+    dependencies:
+      '@borewit/text-codec': 0.1.1
+      '@tokenizer/token': 0.3.0
+      ieee754: 1.2.1
 
   totalist@3.0.1: {}
 
@@ -39915,7 +43211,11 @@ snapshots:
 
   tslib@2.4.0: {}
 
+  tslib@2.6.0: {}
+
   tslib@2.6.2: {}
+
+  tslib@2.7.0: {}
 
   tslib@2.8.0: {}
 
@@ -39958,6 +43258,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  tweetnacl-util@0.13.5: {}
 
   tweetnacl-util@0.15.1: {}
 
@@ -40044,6 +43346,8 @@ snapshots:
 
   typedarray@0.0.6: {}
 
+  typeforce@1.18.0: {}
+
   typeorm@0.3.20(better-sqlite3@9.6.0)(ioredis@5.4.1)(ts-node@10.9.2(@swc/core@1.5.5(@swc/helpers@0.5.11))(@types/node@22.7.6)(typescript@5.4.5)):
     dependencies:
       '@sqltools/formatter': 1.2.5
@@ -40084,9 +43388,11 @@ snapshots:
 
   ufo@1.5.3: {}
 
+  uint8array-extras@1.5.0: {}
+
   uint8arraylist@2.4.8:
     dependencies:
-      uint8arrays: 5.0.1
+      uint8arrays: 5.1.0
 
   uint8arrays@2.1.10:
     dependencies:
@@ -40104,7 +43410,7 @@ snapshots:
     dependencies:
       multiformats: 12.1.3
 
-  uint8arrays@5.0.1:
+  uint8arrays@5.1.0:
     dependencies:
       multiformats: 13.1.0
 
@@ -40339,14 +43645,14 @@ snapshots:
   use-callback-ref@1.3.0(@types/react@18.3.1)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
   use-callback-ref@1.3.2(@types/react@18.3.1)(react@18.3.1):
     dependencies:
       react: 18.3.1
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
@@ -40377,7 +43683,7 @@ snapshots:
     dependencies:
       detect-node-es: 1.1.0
       react: 18.3.1
-      tslib: 2.6.2
+      tslib: 2.8.0
     optionalDependencies:
       '@types/react': 18.3.1
 
@@ -40409,6 +43715,10 @@ snapshots:
 
   utils-merge@1.0.1: {}
 
+  uuid@10.0.0: {}
+
+  uuid@13.0.0: {}
+
   uuid@7.0.3: {}
 
   uuid@8.3.2: {}
@@ -40437,6 +43747,13 @@ snapshots:
   validate-npm-package-name@5.0.1: {}
 
   validator@13.11.0: {}
+
+  valtio@1.11.0(react@18.3.1):
+    dependencies:
+      proxy-compare: 2.5.1
+      use-sync-external-store: 1.2.0(react@18.3.1)
+    optionalDependencies:
+      react: 18.3.1
 
   valtio@1.11.2(@types/react@18.3.1)(react@18.3.1):
     dependencies:
@@ -40480,7 +43797,7 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 0.9.8(typescript@5.4.5)(zod@3.23.8)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       typescript: 5.4.5
@@ -40497,7 +43814,7 @@ snapshots:
       '@scure/bip32': 1.3.2
       '@scure/bip39': 1.2.1
       abitype: 1.0.0(typescript@5.4.5)(zod@3.23.8)
-      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8))
+      isows: 1.0.3(ws@8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3))
       ws: 8.13.0(bufferutil@4.0.8)(utf-8-validate@6.0.3)
     optionalDependencies:
       typescript: 5.4.5
@@ -40509,7 +43826,7 @@ snapshots:
   vite-node@1.6.0(@types/node@22.7.6)(terser@5.36.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.3.4
+      debug: 4.3.7
       pathe: 1.1.2
       picocolors: 1.0.0
       vite: 5.2.11(@types/node@22.7.6)(terser@5.36.0)
@@ -40666,6 +43983,8 @@ snapshots:
 
   web-streams-polyfill@4.0.0:
     optional: true
+
+  web-vitals@3.5.2: {}
 
   web-worker@1.2.0: {}
 
@@ -41104,6 +44423,10 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.0.8
 
+  ws@8.17.1(bufferutil@4.0.8):
+    optionalDependencies:
+      bufferutil: 4.0.8
+
   ws@8.18.0(bufferutil@4.0.8)(utf-8-validate@6.0.3):
     optionalDependencies:
       bufferutil: 4.0.8
@@ -41141,6 +44464,11 @@ snapshots:
   xmlchars@2.2.0: {}
 
   xmlhttprequest-ssl@2.0.0: {}
+
+  xstream@11.14.0:
+    dependencies:
+      globalthis: 1.0.4
+      symbol-observable: 2.0.3
 
   xtend@4.0.2: {}
 


### PR DESCRIPTION
This PR adds did:cheqd support to Masca.

[cheqd](https://cheqd.io) is a Cosmos-based identity chain. This PR allows Masca to interact with the cheqd ledger for DID operations.